### PR TITLE
Fixed invalid "$UNDEFINE" directive

### DIFF
--- a/sdlsyswm.inc
+++ b/sdlsyswm.inc
@@ -14,7 +14,7 @@
  * Disabled because FPC does not ship a DirectFB unit.
  * If you have some working DirectDB bindings, feel welcome to enable this and check if it breaks anything.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_DIRECTFB}
+{$UNDEF SDL_VIDEO_DRIVER_DIRECTFB}
 
 {$IFDEF DARWIN}
    {$DEFINE SDL_VIDEO_DRIVER_COCOA}
@@ -24,25 +24,25 @@
  * Disabled because it's a Mac-specific video driver and we have no means of testing it.
  * If you own a Mac, feel welcome to enable this and check if it actually compiles and doesn't break anything.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_UIKIT}
+{$UNDEF SDL_VIDEO_DRIVER_UIKIT}
 
 (* 
  * Disabled because FPC does not ship a Wayland unit.
  * If you have some working Wayland bindings, feel welcome to enable this,
  * check if it actually compiles and doesn't break anything.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_WAYLAND}
+{$UNDEF SDL_VIDEO_DRIVER_WAYLAND}
 
 (*
  * Disabled because FPC does not ship a Mir unit.
  * Also, support for Mir has been removed in SDL 2.0.10.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_MIR}
+{$UNDEF SDL_VIDEO_DRIVER_MIR}
 
 (*
  * Disabled because FPC does not support WinRT.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_WINRT}
+{$UNDEF SDL_VIDEO_DRIVER_WINRT}
 
 {$IFDEF ANDROID}
    {$DEFINE SDL_VIDEO_DRIVER_ANDROID}
@@ -53,7 +53,7 @@
  * If you're actually working with Vivante, feel welcome to enable this
  * and check if it compiles and works properly.
  *)
-{$UNDEFINE SDL_VIDEO_DRIVER_VIVANTE}
+{$UNDEF SDL_VIDEO_DRIVER_VIVANTE}
 
 {$IFDEF OS2}
    {$DEFINE SDL_VIDEO_DRIVER_OS2}


### PR DESCRIPTION
Invalid "$UNDEFINE" directive replaced with "$UNDEF" to avoid compilation warnings.