### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches: [ master ]
 
 jobs:
+  macos-11:
+    runs-on: macos-11
+    steps:
+      - name: Install FPC
+        run: |
+          brew update
+          brew install fpc
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        run: fpc sdl2.pas
+      - name: Compile SDL2_gfx unit
+        run: fpc sdl2_gfx.pas
+      - name: Compile SDL2_image unit
+        run: fpc sdl2_image.pas
+      - name: Compile SDL2_mixer unit
+        run: fpc sdl2_mixer.pas
+      - name: Compile SDL2_net unit
+        run: fpc sdl2_net.pas
+      - name: Compile SDL2_ttf unit
+        run: fpc sdl2_ttf.pas
   ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install FPC
+        run: |
+           export DEBIAN_FRONTEND=noninteractive
+           sudo apt update
+           sudo apt install fpc
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        run: fpc sdl2.pas
+      - name: Compile SDL2_gfx unit
+        run: fpc sdl2_gfx.pas
+      - name: Compile SDL2_image unit
+        run: fpc sdl2_image.pas
+      - name: Compile SDL2_mixer unit
+        run: fpc sdl2_mixer.pas
+      - name: Compile SDL2_net unit
+        run: fpc sdl2_net.pas
+      - name: Compile SDL2_ttf unit
+        run: fpc sdl2_ttf.pas
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,24 @@ jobs:
         run: fpc sdl2_net.pas
       - name: Compile SDL2_ttf unit
         run: fpc sdl2_ttf.pas
+  windows-2022:
+    runs-on: windows-2022
+    steps:
+      - name: Install Lazarus
+        run: |
+          choco install lazarus
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2.pas
+      - name: Compile SDL2_gfx unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2_gfx.pas
+      - name: Compile SDL2_image unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2_image.pas
+      - name: Compile SDL2_mixer unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2_mixer.pas
+      - name: Compile SDL2_net unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2_net.pas
+      - name: Compile SDL2_ttf unit
+        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe sdl2_ttf.pas
 


### PR DESCRIPTION
This patch adds a single GitHub Actions workflow with three jobs: 

- first one runs on Ubuntu 20.04
- second one runs on MacOS 11
- third one runs on Windows Server 2022

Each of these installs FPC (using `apt` for Ubuntu, `brew` for MacOS and `choco` for Windows) and compiles all the SDL2 units.