### PR TITLE
Use GHActions-FPC in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        run: fpc units/sdl2.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        run: fpc units/sdl2_gfx.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
       - name: Compile SDL2_image unit
-        run: fpc units/sdl2_image.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        run: fpc units/sdl2_mixer.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
       - name: Compile SDL2_net unit
-        run: fpc units/sdl2_net.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        run: fpc units/sdl2_ttf.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
   ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
@@ -39,17 +57,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        run: fpc units/sdl2.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        run: fpc units/sdl2_gfx.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
       - name: Compile SDL2_image unit
-        run: fpc units/sdl2_image.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        run: fpc units/sdl2_mixer.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
       - name: Compile SDL2_net unit
-        run: fpc units/sdl2_net.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        run: fpc units/sdl2_ttf.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
   windows-2022:
     runs-on: windows-2022
     steps:
@@ -59,15 +95,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2_gfx.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
       - name: Compile SDL2_image unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2_image.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2_mixer.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
       - name: Compile SDL2_net unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2_net.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        run: C:/lazarus/fpc/*/bin/x86_64-win64/fpc.exe units/sdl2_ttf.pas
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
 


### PR DESCRIPTION
This patch converts the CI workflow to use [GHActions-FPC](https://github.com/marketplace/actions/free-pascal-compiler), instead of running FPC directly. This will bring in the advantage of having annotations generated on pull requests.