### PR TITLE
Add (first) test (SDL_Init), compilation and execution workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,8 @@ jobs:
       - name: Test 1 - Run Init Test
         run: |
           ./tests/testinit.exe
+      #  !!! Since no SDL2.DLL is available via chocolatey, the run will fail.
+      #      TODO: Find solution.
+      #  - name: Test 1 - Run Init Test
+      #    run: |
+      #      ./tests/testinit.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,45 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  macos-11:
-    runs-on: macos-11
-    steps:
-      - name: Install FPC
-        run: |
-          brew update
-          brew install fpc
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2.pas
-          verbosity: ewnh
-      - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_gfx.pas
-          verbosity: ewnh
-      - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_image.pas
-          verbosity: ewnh
-      - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_mixer.pas
-          verbosity: ewnh
-      - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_net.pas
-          verbosity: ewnh
-      - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_ttf.pas
-          verbosity: ewnh
   ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
@@ -93,47 +54,3 @@ jobs:
         with:
           source: tests/testinit.pas
           verbosity: ewnh
-  windows-2022:
-    runs-on: windows-2022
-    steps:
-      - name: Install Lazarus
-        run: |
-          choco install lazarus
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2.pas
-          verbosity: ewnh
-      - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_gfx.pas
-          verbosity: ewnh
-      - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_image.pas
-          verbosity: ewnh
-      - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_mixer.pas
-          verbosity: ewnh
-      - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_net.pas
-          verbosity: ewnh
-      - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_ttf.pas
-          verbosity: ewnh
-      - name: Test 1 - Compile Init Test
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: tests/testinit.pas
-          verbosity: ewnh
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
           verbosity: ewnh
       - name: Install SDL2 library
         run: brew install sdl2
-      - name: Check SDL2 library version
-        run: sdl2-config --version
-      - name: Get SDL2 library path
-        run: sdl2-config --libs
+      - name: Get SDL2 library version and path(s)
+        run: |
+          sdl2-config --version
+          sdl2-config --libs
       - name: Test 1 - Compile Init Test
         uses: suve/GHActions-FPC@v0.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,6 @@ jobs:
           verbosity: ewnh
       - name: Test 1 - Run Init Test
         run: |
+          mkdir ~/tmp
+          export XDG_RUNTIME_DIR=~/tmp
           ./tests/testinit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         uses: suve/GHActions-FPC@v0.3.2
         with:
           source: tests/testinit.pas
+          flags: Flunits
           verbosity: ewnh
       - name: Test 1 - Run Init Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         uses: suve/GHActions-FPC@v0.3.2
         with:
           source: tests/testinit.pas
+          flags: Fl/usr/local/lib
           verbosity: ewnh
   macos-11-big-sur:
     runs-on: macos-11
@@ -106,4 +107,5 @@ jobs:
         uses: suve/GHActions-FPC@v0.3.2
         with:
           source: tests/testinit.pas
+          flags: Fl/usr/local/lib
           verbosity: ewnh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,9 @@ jobs:
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
+      - name: Test 1 - Compile Init Test
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: tests/testinit.pas
+          verbosity: ewnh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,57 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  macos-10-catalina:
-    runs-on: macos-10.15
-    steps:
-      - name: Install FPC
-        run: |
-          brew update
-          brew install fpc
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2.pas
-          verbosity: ewnh
-      - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_gfx.pas
-          verbosity: ewnh
-      - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_image.pas
-          verbosity: ewnh
-      - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_mixer.pas
-          verbosity: ewnh
-      - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_net.pas
-          verbosity: ewnh
-      - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: units/sdl2_ttf.pas
-          verbosity: ewnh
-      - name: Install SDL2 library
-        run: brew install sdl2
-      - name: Check SDL2 library version
-        run: sdl2-config --version
-      - name: Get SDL2 library path
-        run: sdl2-config --libs
-      - name: Test 1 - Compile Init Test
-        uses: suve/GHActions-FPC@v0.3.2
-        with:
-          source: tests/testinit.pas
-          flags: Fl/usr/local/lib
-          verbosity: ewnh
   macos-11-big-sur:
     runs-on: macos-11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,12 @@ on:
     branches: [ master ]
 
 jobs:
-  ubuntu-20-04:
-    runs-on: ubuntu-20.04
+  windows-2022:
+    runs-on: windows-2022
     steps:
-      - name: Install FPC
+      - name: Install Lazarus
         run: |
-           export DEBIAN_FRONTEND=noninteractive
-           sudo apt update
-           sudo apt install fpc
+          choco install lazarus
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
@@ -47,8 +45,6 @@ jobs:
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
-      - name: Install SDL2 library
-        run: sudo apt-get install libsdl2-dev
       - name: Test 1 - Compile Init Test
         uses: suve/GHActions-FPC@v0.3.2
         with:
@@ -56,6 +52,4 @@ jobs:
           verbosity: ewnh
       - name: Test 1 - Run Init Test
         run: |
-          mkdir ~/tmp
-          export XDG_RUNTIME_DIR=~/tmp
-          ./tests/testinit
+          ./tests/testinit.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
+      - name: Install SDL2 library
+        run: sudo apt-get install libsdl2-dev
+      - name: Test 1 - Compile Init Test
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: tests/testinit.pas
+          verbosity: ewnh
   windows-2022:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,6 @@ jobs:
         with:
           source: tests/testinit.pas
           verbosity: ewnh
+      - name: Test 1 - Run Init Test
+        run: |
+          ./tests/testinit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,13 @@ on:
     branches: [ master ]
 
 jobs:
-  windows-2022:
-    runs-on: windows-2022
+  macos-10-catalina:
+    runs-on: macos-10.15
     steps:
-      - name: Install Lazarus
+      - name: Install FPC
         run: |
-          choco install lazarus
+          brew update
+          brew install fpc
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
@@ -45,17 +46,64 @@ jobs:
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
+      - name: Install SDL2 library
+        run: brew install sdl2
+      - name: Check SDL2 library version
+        run: sdl2-config --version
+      - name: Get SDL2 library path
+        run: sdl2-config --libs
       - name: Test 1 - Compile Init Test
         uses: suve/GHActions-FPC@v0.3.2
         with:
           source: tests/testinit.pas
-          flags: Flunits
           verbosity: ewnh
-      - name: Test 1 - Run Init Test
+  macos-11-big-sur:
+    runs-on: macos-11
+    steps:
+      - name: Install FPC
         run: |
-          ./tests/testinit.exe
-      #  !!! Since no SDL2.DLL is available via chocolatey, the run will fail.
-      #      TODO: Find solution.
-      #  - name: Test 1 - Run Init Test
-      #    run: |
-      #      ./tests/testinit.exe
+          brew update
+          brew install fpc
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
+      - name: Compile SDL2_gfx unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
+      - name: Compile SDL2_image unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
+      - name: Compile SDL2_mixer unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
+      - name: Compile SDL2_net unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
+      - name: Compile SDL2_ttf unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
+      - name: Install SDL2 library
+        run: brew install sdl2
+      - name: Check SDL2 library version
+        run: sdl2-config --version
+      - name: Get SDL2 library path
+        run: sdl2-config --libs
+      - name: Test 1 - Compile Init Test
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: tests/testinit.pas
+          verbosity: ewnh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,104 @@ jobs:
       - name: Test 1 - Run Init Test
         run: |
           ./tests/testinit
+  ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install FPC
+        run: |
+           export DEBIAN_FRONTEND=noninteractive
+           sudo apt update
+           sudo apt install fpc
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
+      - name: Compile SDL2_gfx unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
+      - name: Compile SDL2_image unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
+      - name: Compile SDL2_mixer unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
+      - name: Compile SDL2_net unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
+      - name: Compile SDL2_ttf unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
+      - name: Install SDL2 library
+        run: sudo apt-get install libsdl2-dev
+      - name: Test 1 - Compile Init Test
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: tests/testinit.pas
+          verbosity: ewnh
+      - name: Test 1 - Run Init Test
+        run: |
+          mkdir ~/tmp
+          export XDG_RUNTIME_DIR=~/tmp
+          ./tests/testinit
+  windows-2022:
+    runs-on: windows-2022
+    steps:
+      - name: Install Lazarus
+        run: |
+          choco install lazarus
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Compile SDL2 unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2.pas
+          verbosity: ewnh
+      - name: Compile SDL2_gfx unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_gfx.pas
+          verbosity: ewnh
+      - name: Compile SDL2_image unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_image.pas
+          verbosity: ewnh
+      - name: Compile SDL2_mixer unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_mixer.pas
+          verbosity: ewnh
+      - name: Compile SDL2_net unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_net.pas
+          verbosity: ewnh
+      - name: Compile SDL2_ttf unit
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: units/sdl2_ttf.pas
+          verbosity: ewnh
+      - name: Test 1 - Compile Init Test
+        uses: suve/GHActions-FPC@v0.3.2
+        with:
+          source: tests/testinit.pas
+          flags: Flunits
+          verbosity: ewnh
+      #  !!! Since no SDL2.DLL is available via chocolatey, the run will fail.
+      #      TODO: Find solution to install SDL2 binary.
+      #  - name: Test 1 - Run Init Test
+      #    run: |
+      #      ./tests/testinit.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,6 @@ jobs:
           source: tests/testinit.pas
           flags: Fl/usr/local/lib
           verbosity: ewnh
+      - name: Test 1 - Run Init Test
+        run: |
+          ./tests/testinit

--- a/tests/testinit.pas
+++ b/tests/testinit.pas
@@ -1,0 +1,56 @@
+program testinit;
+
+{
+
+  Test initilization of SDL2 system with a sample of flags.
+
+  This file is part of
+
+    SDL2-for-Pascal
+    Copyright (C) 2020-2022 PGD Community
+    Visit: https://github.com/PascalGameDevelopment/SDL2-for-Pascal
+
+}
+
+{$I testsettings.inc}
+
+uses
+  Classes, SysUtils, SDL2;
+
+type
+  ESDL2Error = class(Exception);
+
+const
+  Flags: array[0..12] of TSDL_Init = (
+    { single flags }
+    SDL_INIT_TIMER, SDL_INIT_AUDIO, SDL_INIT_VIDEO,
+    SDL_INIT_JOYSTICK, SDL_INIT_HAPTIC, SDL_INIT_GAMECONTROLLER,
+    SDL_INIT_EVENTS, SDL_INIT_SENSOR, SDL_INIT_NOPARACHUTE,
+    SDL_INIT_EVERYTHING,
+    { typically combined flags }
+    SDL_INIT_AUDIO or SDL_INIT_VIDEO,
+    SDL_INIT_VIDEO or SDL_INIT_JOYSTICK,
+    SDL_INIT_VIDEO or SDL_INIT_GAMECONTROLLER or SDL_INIT_AUDIO);
+
+var
+  Flag: TSDL_Init;
+begin
+  write('Start SDL2 inilization test... ');
+  for Flag in Flags do
+  begin
+    try
+      if SDL_Init(Flag) <> 0 then
+        raise ESDL2Error.Create('SDL_Init failed: Flag = ' + IntToStr(Flag));
+    except
+      on E: ESDL2Error do
+      try
+        SDL_Quit;
+      except
+        raise;
+      end;
+    end;
+    SDL_Quit;
+  end;
+  writeln(' finished.');
+end.
+

--- a/tests/testsettings.inc
+++ b/tests/testsettings.inc
@@ -1,0 +1,5 @@
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+  {$UNITPATH ../units}                 // Does this work in Delphi?
+{$ENDIF}
+

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -125,6 +125,9 @@ const
   {$IFDEF UNIX}
     {$IFDEF DARWIN}
       SDL_LibName = 'libSDL2.dylib';
+      {$IFDEF FPC}
+        {$LINKLIB libSDL2}
+      {$ENDIF}
     {$ELSE}
       {$IFDEF FPC}
         SDL_LibName = 'libSDL2.so';


### PR DESCRIPTION
- this test tries to inilialize SDL2 with different flags
- it does not rely on FPUnit or DUnit to be simple and usable for FPC and Delphi (see issue https://github.com/PascalGameDevelopment/SDL2-for-Pascal/issues/21)
- this PR is also a try to test if the workflow for testing for SDL2 for Pascal is working as expected (including Action script)
- fixes library linking for Darwin/MacOS