### PR TITLE
Update sdltimer.inc to v2.0.18

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -153,7 +153,7 @@ const
 {$I sdlpower.inc}                // 2.0.14
 {$I sdlthread.inc}
 {$I sdlmutex.inc}                // 2.0.14 WIP
-{$I sdltimer.inc}                // 2.0.14
+{$I sdltimer.inc}                // 2.0.18
 {$I sdlpixels.inc}               // 2.0.14 WIP
 {$I sdlrect.inc}                 // 2.0.14
 {$I sdlrwops.inc}                // 2.0.14

--- a/units/sdltimer.inc
+++ b/units/sdltimer.inc
@@ -9,6 +9,17 @@ function SDL_GetTicks: cuint32; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTicks' {$ENDIF} {$ENDIF};
 
 {**
+ * Get the number of milliseconds since SDL library initialization.
+ *
+ * Note that you should not use the SDL_TICKS_PASSED macro with values
+ * returned by this function, as that macro does clever math to compensate for
+ * the 32-bit overflow every ~49 days that SDL_GetTicks() suffers from. 64-bit
+ * values from this function can be safely compared directly.
+ *}
+function SDL_GetTicks64: cuint64; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTicks64' {$ENDIF} {$ENDIF};
+
+{**
  * \brief Compare SDL ticks values, and return true if A has passed B
  *
  * e.g. if you want to wait 100 ms, you could do this:


### PR DESCRIPTION
This patch updates `units/sdltimer.inc` to match the v2.0.18 version of `SDL_timer.h`.