### PR TITLE
Add sdlatomic.inc

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -247,6 +247,20 @@ begin
   Result := (a^.x = b^.x) and (a^.y = b^.y) and (a^.w = b^.w) and (a^.h = b^.h);
 end;
 
+//from "sdl_atomic.h"
+function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
+begin
+  Result := SDL_AtomicAdd(atomic, 1)
+end;
+
+function SDL_AtomicDecRef(atomic: PSDL_Atomic): TSDL_bool;
+begin
+  If SDL_AtomicAdd(atomic, -1) = 1 then
+    Result := SDL_TRUE
+  else
+    Result := SDL_FALSE
+end;
+
 //from "sdl_audio.h"
 
 function SDL_LoadWAV(_file: PAnsiChar; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): PSDL_AudioSpec;

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -258,6 +258,20 @@ begin
   Result := SDL_AtomicAdd(atomic, -1) = 1
 end;
 
+procedure SDL_CompilerBarrier();
+{$IFDEF FPC}
+begin
+  ReadWriteBarrier()
+{$ELSE}
+var
+  lock: TSDL_SpinLock;
+begin
+  lock := 0;
+  SDL_AtomicLock(@lock);
+  SDL_AtomicUnlock(@lock)
+{$ENDIF}
+end;
+
 //from "sdl_audio.h"
 
 function SDL_LoadWAV(_file: PAnsiChar; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): PSDL_AudioSpec;

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -152,6 +152,7 @@ const
 {$I sdlplatform.inc}             // 2.0.14
 {$I sdlpower.inc}                // 2.0.14
 {$I sdlthread.inc}
+{$I sdlatomic.inc}               // 2.0.6  WIP
 {$I sdlmutex.inc}                // 2.0.14 WIP
 {$I sdltimer.inc}                // 2.0.14
 {$I sdlpixels.inc}               // 2.0.14 WIP

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -152,7 +152,7 @@ const
 {$I sdlplatform.inc}             // 2.0.14
 {$I sdlpower.inc}                // 2.0.14
 {$I sdlthread.inc}
-{$I sdlatomic.inc}               // 2.0.6, missing SDL_CompilerBarrier()
+{$I sdlatomic.inc}               // 2.0.20
 {$I sdlmutex.inc}                // 2.0.14 WIP
 {$I sdltimer.inc}                // 2.0.14
 {$I sdlpixels.inc}               // 2.0.14 WIP

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -152,7 +152,7 @@ const
 {$I sdlplatform.inc}             // 2.0.14
 {$I sdlpower.inc}                // 2.0.14
 {$I sdlthread.inc}
-{$I sdlatomic.inc}               // 2.0.6  WIP
+{$I sdlatomic.inc}               // 2.0.6, missing SDL_CompilerBarrier()
 {$I sdlmutex.inc}                // 2.0.14 WIP
 {$I sdltimer.inc}                // 2.0.14
 {$I sdlpixels.inc}               // 2.0.14 WIP
@@ -253,12 +253,9 @@ begin
   Result := SDL_AtomicAdd(atomic, 1)
 end;
 
-function SDL_AtomicDecRef(atomic: PSDL_Atomic): TSDL_bool;
+function SDL_AtomicDecRef(atomic: PSDL_Atomic): Boolean;
 begin
-  If SDL_AtomicAdd(atomic, -1) = 1 then
-    Result := SDL_TRUE
-  else
-    Result := SDL_FALSE
+  Result := SDL_AtomicAdd(atomic, -1) = 1
 end;
 
 //from "sdl_audio.h"

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -79,7 +79,7 @@ function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
  * Decrement an atomic variable used as a reference count
  * and check if it reached zero after decrementing.
  *}
-function SDL_AtomicDecRef(atomic: PSDL_Atomic): TSDL_bool;
+function SDL_AtomicDecRef(atomic: PSDL_Atomic): Boolean;
 
 {**
  * Set a pointer to a new value if it is currently an old value.

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -71,3 +71,13 @@ function SDL_AtomicGet(atomic: PSDL_Atomic): cint; cdecl;
 function SDL_AtomicAdd(atomic: PSDL_Atomic; value: cint): cint; cdecl;
 	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicAdd' {$ENDIF} {$ENDIF};
 
+{**
+ * Increment an atomic variable used as a reference count.
+ *}
+function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
+{**
+ * Decrement an atomic variable used as a reference count
+ * and check if it reached zero after decrementing.
+ *}
+function SDL_AtomicDecRef(atomic: PSDL_Atomic): TSDL_bool;
+

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -1,0 +1,35 @@
+// from SDL_atomic.h
+
+{**
+ * Atomic locks are efficient spinlocks using CPU instructions,
+ * but are vulnerable to starvation and can spin forever if a thread
+ * holding a lock has been terminated.  For this reason you should
+ * minimize the code executed inside an atomic lock and never do
+ * expensive things like API or system calls while holding them.
+ *
+ * The atomic locks are not safe to lock recursively.
+ *}
+type
+	PSDL_SpinLock = ^TSDL_SpinLock;
+	TSDL_SpinLock = type cint;
+
+{**
+ * Try to lock a spin lock by setting it to a non-zero value.
+ *}
+function SDL_AtomicTryLock(lock: PSDL_SpinLock): TSDL_bool; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicTryLock' {$ENDIF} {$ENDIF};
+
+{**
+ * Lock a spin lock by setting it to a non-zero value.
+ *}
+function SDL_AtomicLock(lock: PSDL_SpinLock): TSDL_bool; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicLock' {$ENDIF} {$ENDIF};
+
+{**
+ * Unlock a spin lock by setting it to 0.
+ *
+ * Always returns immediately.
+ *} 
+procedure SDL_AtomicUnlock(lock: PSDL_SpinLock); cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicUnlock' {$ENDIF} {$ENDIF};
+

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -33,6 +33,12 @@ function SDL_AtomicLock(lock: PSDL_SpinLock): TSDL_bool; cdecl;
 procedure SDL_AtomicUnlock(lock: PSDL_SpinLock); cdecl;
 	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicUnlock' {$ENDIF} {$ENDIF};
 
+{**
+ * The compiler barrier prevents the compiler from reordering
+ * reads and writes to globally visible variables across the call.
+ *}
+procedure SDL_CompilerBarrier();
+
 type
 	PSDL_Atomic = ^TSDL_Atomic;
 	{**

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -81,3 +81,21 @@ function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
  *}
 function SDL_AtomicDecRef(atomic: PSDL_Atomic): TSDL_bool;
 
+{**
+ * Set a pointer to a new value if it is currently an old value.
+ *}
+function SDL_AtomicCASPtr(ptr: PPointer; oldValue, newValue: Pointer): TSDL_bool; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicCASPtr' {$ENDIF} {$ENDIF};
+
+{**
+ * Set a pointer to a new value atomically, and return the old value.
+ *}
+function SDL_AtomicSetPtr(ptr: PPointer; value: Pointer): Pointer; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicSetPtr' {$ENDIF} {$ENDIF};
+
+{**
+ * Get the value of a pointer atomically.
+ *}
+function SDL_AtomicGetPtr(ptr: PPointer): Pointer; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicGetPtr' {$ENDIF} {$ENDIF};
+

--- a/units/sdlatomic.inc
+++ b/units/sdlatomic.inc
@@ -29,7 +29,45 @@ function SDL_AtomicLock(lock: PSDL_SpinLock): TSDL_bool; cdecl;
  * Unlock a spin lock by setting it to 0.
  *
  * Always returns immediately.
- *} 
+ *}
 procedure SDL_AtomicUnlock(lock: PSDL_SpinLock); cdecl;
 	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicUnlock' {$ENDIF} {$ENDIF};
+
+type
+	PSDL_Atomic = ^TSDL_Atomic;
+	{**
+	 * A type representing an atomic integer value.  It is a record
+	 * so people don't accidentally use numeric operations on it.
+	 *}
+	TSDL_Atomic = record
+		Value: cint
+	end;
+
+{**
+ * Set an atomic variable to a new value if it is currently an old value.
+ *}
+function SDL_AtomicCAS(atomic: PSDL_Atomic; oldValue, newValue: cint): TSDL_bool; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicCAS' {$ENDIF} {$ENDIF};
+
+{**
+ * Set an atomic variable to a new value and return the old one.
+ *
+ * This function also acts as a full memory barrier.
+ *}
+function SDL_AtomicSet(atomic: PSDL_Atomic; value: cint): cint; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicSet' {$ENDIF} {$ENDIF};
+
+{**
+ * Get the value of an atomic variable.
+ *}
+function SDL_AtomicGet(atomic: PSDL_Atomic): cint; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicGet' {$ENDIF} {$ENDIF};
+
+{**
+ * Add to an atomic variable, and return the old value.
+ *
+ * This function also acts as a full memory barrier.
+ *}
+function SDL_AtomicAdd(atomic: PSDL_Atomic; value: cint): cint; cdecl;
+	external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AtomicAdd' {$ENDIF} {$ENDIF};
 


### PR DESCRIPTION
This patch adds `units/sdlatomic.inc`, based on `SDL_atomic.h`.

The `SDL_CompilerBarrier()` function is missing because it's actually [a C macro](https://github.com/libsdl-org/SDL/blob/b424665e0899769b200231ba943353a5fee1b6b6/include/SDL_atomic.h#L147) that evaluates differently based on the compiler. We could, alternatively, make this a Pascal function that matches the macro's [generic/fallback version](https://github.com/libsdl-org/SDL/blob/b424665e0899769b200231ba943353a5fee1b6b6/include/SDL_atomic.h#L158).