### PR TITLE
#42 — SDL_JoystickHasLED — invalid parameter removed

### DIFF
--- a/units/sdljoystick.inc
+++ b/units/sdljoystick.inc
@@ -476,7 +476,7 @@ function SDL_JoystickRumbleTriggerse(joystick: PSDL_Joystick; left_rumble: cuint
  *
  *  \return SDL_TRUE, or SDL_FALSE if this joystick does not have a modifiable LED
  *}
-function SDL_JoystickHasLED(joystick: PSDL_Joystick; button: cint32): TSDL_Bool; cdecl;
+function SDL_JoystickHasLED(joystick: PSDL_Joystick): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickHasLED' {$ENDIF} {$ENDIF};
 
 {**


### PR DESCRIPTION
According to the official documentation, the function "SDL_JoystickHasLED" has one parameter, which is the joystick handle.