### PR TITLE
Update SDL2_ttf to 2.0.18

### DIFF
--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -374,6 +374,12 @@ function TTF_GetFontKerningSize(font: PTTF_Font; prev_index, index: cint): cint 
 function TTF_GetFontKerningSizeGlyphs(font: PTTF_Font; previous_ch, ch: cuint16): cint cdecl;
   external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerningSizeGlyphs' {$ENDIF} {$ENDIF};
 
+{* Enable Signed Distance Field rendering (with the Blended APIs) *}
+function TTF_SetFontSDF(font: PTTF_Font; on_off: TSDL_Bool): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSDF' {$ENDIF} {$ENDIF};
+function TTF_GetFontSDF(font: PTTF_Font): TSDL_Bool;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontSDF' {$ENDIF} {$ENDIF};
+
 {* We'll use SDL for reporting errors *}
 function TTF_SetError(const fmt: PAnsiChar): cint32; cdecl;
 function TTF_GetError: PAnsiChar; cdecl;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -371,8 +371,10 @@ function TTF_GetFontKerningSize(font: PTTF_Font; prev_index, index: cint): cint 
   deprecated 'This function requires FreeType font indexes, not glyphs. Use TTF_GetFontKerningSizeGlyphs() instead';
 
 {* Get the kerning size of two glyphs *}
-function TTF_GetFontKerningSizeGlyphs(font: PTTF_Font; previous_ch, ch: cuint16): cint cdecl;
-  external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerningSizeGlyphs' {$ENDIF} {$ENDIF};
+function TTF_GetFontKerningSizeGlyphs(font: PTTF_Font; previous_ch, ch: cUint16): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerningSizeGlyphs' {$ENDIF} {$ENDIF};
+function TTF_GetFontKerningSizeGlyphs32(font: PTTF_Font; previous_ch, ch: cUint32): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerningSizeGlyphs32' {$ENDIF} {$ENDIF};
 
 {* Enable Signed Distance Field rendering (with the Blended APIs) *}
 function TTF_SetFontSDF(font: PTTF_Font; on_off: TSDL_Bool): cint;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -214,6 +214,22 @@ function TTF_SizeText(font: PTTF_Font; text: PAnsiChar; w, h: pcint): cint cdecl
 function TTF_SizeUTF8(font: PTTF_Font; text: PAnsiChar; w, h: pcint): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SizeUTF8' {$ENDIF} {$ENDIF};
 function TTF_SizeUNICODE(font: PTTF_Font; text: pcuint16; w, h: pcint): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SizeUNICODE' {$ENDIF} {$ENDIF};
 
+{* Get the measurement string of text without rendering
+   e.g. the number of characters that can be rendered before reaching 'measure_width'
+
+   inputs:
+     measure_width - in pixels to measure this text
+   outputs:
+     count  - number of characters that can be rendered
+     extent - latest calculated width
+*}
+function TTF_MeasureText(font: PTTF_Font; text: PAnsiChar; measure_width: cint; extent, count: pcint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_MeasureText' {$ENDIF} {$ENDIF};
+function TTF_MeasureUTF8(font: PTTF_Font; text: PAnsiChar; measure_width: cint; extent, count: pcint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_MeasureUTF8' {$ENDIF} {$ENDIF};
+function TTF_MeasureUNICODE(font: PTTF_Font; text: pcUint16; measure_width: cint; extent, count: pcint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_MeasureUNICODE' {$ENDIF} {$ENDIF};
+
 {* Create an 8-bit palettized surface and render the given text at
    fast quality with the given font and color.  The 0 pixel is the
    colorkey, giving a transparent background, and the 1 pixel is set

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -119,10 +119,16 @@ function TTF_Init(): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MA
  * Some .fon fonts will have several sizes embedded in the file, so the
  * point size becomes the index of choosing which size.  If the value
  * is too high, the last indexed size will be the default. *}
-function TTF_OpenFont(_file: PAnsiChar; ptsize: cint): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFont' {$ENDIF} {$ENDIF};
-function TTF_OpenFontIndex(_file: PAnsiChar; ptsize: cint; index: LongInt): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndex' {$ENDIF} {$ENDIF};
-function TTF_OpenFontRW(src: PSDL_RWops; freesrc: cint; ptsize: LongInt): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontRW' {$ENDIF} {$ENDIF};
-function TTF_OpenFontIndexRW(src: PSDL_RWops; freesrc: cint; ptsize: cint; index: LongInt): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexRW' {$ENDIF} {$ENDIF};
+function TTF_OpenFont(_file: PAnsiChar; ptsize: cint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFont' {$ENDIF} {$ENDIF};
+function TTF_OpenFontIndex(_file: PAnsiChar; ptsize: cint; index: clong): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndex' {$ENDIF} {$ENDIF};
+{* Open a font file from a SDL_RWops: 'src' must be kept alive for the lifetime of the TTF_Font.
+ * 'freesrc' can be set so that TTF_CloseFont closes the RWops *}
+function TTF_OpenFontRW(src: PSDL_RWops; freesrc, ptsize: cint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontRW' {$ENDIF} {$ENDIF};
+function TTF_OpenFontIndexRW(src: PSDL_RWops; freesrc, ptsize: cint; index: clong): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexRW' {$ENDIF} {$ENDIF};
 
 {* Opens a font using the given horizontal and vertical target resolutions (in DPI).
  * DPI scaling only applies to scalable fonts (e.g. TrueType).

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -263,7 +263,10 @@ function TTF_RenderUNICODE_Solid_Wrapped(font: PTTF_Font; text: pcUint16; fg: TS
    centering in the X direction, and aligned normally in the Y direction.
    This function returns the new surface, or NULL if there was an error.
 *}
-function TTF_RenderGlyph_Solid(font: PTTF_Font; ch: cuint16; fg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Solid' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Solid(font: PTTF_Font; ch: cUint16; fg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Solid' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Solid32(font: PTTF_Font; ch: cUint32; fg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Solid32' {$ENDIF} {$ENDIF};
 
 {* Create an 8-bit palettized surface and render the given text at
    high quality with the given font and colors.  The 0 pixel is background,
@@ -296,7 +299,10 @@ function TTF_RenderUNICODE_Shaded_Wrapped(font: PTTF_Font; text: pcUint16; fg, b
    direction, and aligned normally in the Y direction.
    This function returns the new surface, or NULL if there was an error.
 *}
-function TTF_RenderGlyph_Shaded(font: PTTF_Font; ch: cuint16; fg, bg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Shaded' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Shaded(font: PTTF_Font; ch: cUint16; fg, bg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Shaded' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Shaded32(font: PTTF_Font; ch: cUint32; fg, bg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Shaded32' {$ENDIF} {$ENDIF};
 
 {* Create a 32-bit ARGB surface and render the given text at high quality,
    using alpha blending to dither the font with the given color.
@@ -322,7 +328,10 @@ function TTF_RenderUNICODE_Blended_Wrapped(font: PTTF_Font; text: pcuint16; fg: 
    direction, and aligned normally in the Y direction.
    This function returns the new surface, or NULL if there was an error.
 *}
-function TTF_RenderGlyph_Blended(font: PTTF_Font; ch: cuint16; fg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Blended' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Blended(font: PTTF_Font; ch: cUint16; fg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Blended' {$ENDIF} {$ENDIF};
+function TTF_RenderGlyph_Blended32(font: PTTF_Font; ch: cUint32; fg: TSDL_Color): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph_Blended32' {$ENDIF} {$ENDIF};
 
 {* For compatibility with previous versions, here are the old functions *}
 function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -338,6 +338,17 @@ function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): P
 function TTF_RenderUTF8(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;
 function TTF_RenderUNICODE(font: PTTF_Font; text: pcuint16; fg, bg: TSDL_Color): PSDL_Surface;
 
+{* Set Direction and Script to be used for text shaping, when using HarfBuzz.
+   - direction is of type hb_direction_t
+   - script is of type hb_script_t
+
+   This functions returns always 0, or -1 if SDL_ttf is not compiled with HarfBuzz
+*}
+function TTF_SetDirection(direction: cint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetDirection' {$ENDIF} {$ENDIF};
+function TTF_SetScript(script: cint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetScript' {$ENDIF} {$ENDIF};
+
 {* Close an opened font file *}
 procedure TTF_CloseFont(font: PTTF_Font) cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_CloseFont' {$ENDIF} {$ENDIF};
 

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -157,10 +157,11 @@ procedure TTF_SetFontOutline(font: PTTF_Font; outline: cint) cdecl; external TTF
 
 {* Set and retrieve FreeType hinter settings *}
 const
-  TTF_HINTING_NORMAL  = 0;
-  TTF_HINTING_LIGHT   = 1;
-  TTF_HINTING_MONO    = 2;
-  TTF_HINTING_NONE    = 3;
+  TTF_HINTING_NORMAL         = 0;
+  TTF_HINTING_LIGHT          = 1;
+  TTF_HINTING_MONO           = 2;
+  TTF_HINTING_NONE           = 3;
+  TTF_HINTING_LIGHT_SUBPIXEL = 4;
 
 function TTF_GetFontHinting(font: PTTF_Font): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontHinting' {$ENDIF} {$ENDIF};
 procedure TTF_SetFontHinting(font: PTTF_Font; hinting: cint) cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontHinting' {$ENDIF} {$ENDIF};

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -136,6 +136,12 @@ function TTF_OpenFontDPIRW(src: PSDL_RWops; freesrc, ptsize: cint; hdpi, vdpi: c
 function TTF_OpenFontIndexDPIRW(src: PSDL_RWops; freesrc, ptsize: cuint; index: clong; hdpi, vdpi: cuint): PTTF_Font;
   cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexDPIRW' {$ENDIF} {$ENDIF};
 
+{* Set font size dynamically *}
+function TTF_SetFontSize(font: PTTF_Font; ptsize: cint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSize' {$ENDIF} {$ENDIF};
+function TTF_SetFontSizeDPI(font: PTTF_Font; ptsize: cint; hdpi, vdpi: cuint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSizeDPI' {$ENDIF} {$ENDIF};
+
 {* Set and retrieve the font style *}
 const
   TTF_STYLE_NORMAL        = $00;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -240,6 +240,22 @@ function TTF_RenderText_Solid(font: PTTF_Font; text: PAnsiChar; fg: TSDL_Color):
 function TTF_RenderUTF8_Solid(font: PTTF_Font; text: PAnsiChar; fg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUTF8_Solid' {$ENDIF} {$ENDIF};
 function TTF_RenderUNICODE_Solid(font: PTTF_Font; text: pcuint16; fg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUNICODE_Solid' {$ENDIF} {$ENDIF};
 
+{* Create an 8-bit palettized surface and render the given text at
+   fast quality with the given font and color.  The 0 pixel is the
+   colorkey, giving a transparent background, and the 1 pixel is set
+   to the text color.
+   Text is wrapped to multiple lines on line endings and on word boundaries
+   if it extends beyond wrapLength in pixels.
+   If wrapLength is 0, only wrap on new lines.
+   This function returns the new surface, or NULL if there was an error.
+*}
+function TTF_RenderText_Solid_Wrapped(font: PTTF_Font; text: PAnsiChar; fg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderText_Solid_Wrapped' {$ENDIF} {$ENDIF};
+function TTF_RenderUTF8_Solid_Wrapped(font: PTTF_Font; text: PAnsiChar; fg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUTF8_Solid_Wrapped' {$ENDIF} {$ENDIF};
+function TTF_RenderUNICODE_Solid_Wrapped(font: PTTF_Font; text: pcUint16; fg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUNICODE_Solid_Wrapped' {$ENDIF} {$ENDIF};
+
 {* Create an 8-bit palettized surface and render the given glyph at
    fast quality with the given font and color.  The 0 pixel is the
    colorkey, giving a transparent background, and the 1 pixel is set

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -124,6 +124,18 @@ function TTF_OpenFontIndex(_file: PAnsiChar; ptsize: cint; index: LongInt): PTTF
 function TTF_OpenFontRW(src: PSDL_RWops; freesrc: cint; ptsize: LongInt): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontRW' {$ENDIF} {$ENDIF};
 function TTF_OpenFontIndexRW(src: PSDL_RWops; freesrc: cint; ptsize: cint; index: LongInt): PTTF_Font cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexRW' {$ENDIF} {$ENDIF};
 
+{* Opens a font using the given horizontal and vertical target resolutions (in DPI).
+ * DPI scaling only applies to scalable fonts (e.g. TrueType).
+ *}
+function TTF_OpenFontDPI(file_: PAnsiChar; ptsize: cint; hdpi, vdpi: cuint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontDPI' {$ENDIF} {$ENDIF};
+function TTF_OpenFontIndexDPI(file_: PAnsiChar; ptsize: cint; index: clong; hdpi, vdpi: cuint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexDPI' {$ENDIF} {$ENDIF};
+function TTF_OpenFontDPIRW(src: PSDL_RWops; freesrc, ptsize: cint; hdpi, vdpi: cuint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontDPIRW' {$ENDIF} {$ENDIF};
+function TTF_OpenFontIndexDPIRW(src: PSDL_RWops; freesrc, ptsize: cuint; index: clong; hdpi, vdpi: cuint): PTTF_Font;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIndexDPIRW' {$ENDIF} {$ENDIF};
+
 {* Set and retrieve the font style *}
 const
   TTF_STYLE_NORMAL        = $00;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -68,7 +68,7 @@ const
 const
   SDL_TTF_MAJOR_VERSION = 2;
   SDL_TTF_MINOR_VERSION = 0;
-  SDL_TTF_PATCHLEVEL    = 15;
+  SDL_TTF_PATCHLEVEL    = 18;
 
 Procedure SDL_TTF_VERSION(Out X:TSDL_Version);
 

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -84,6 +84,18 @@ const
  *}
 function TTF_Linked_Version: PSDL_Version cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_Linked_Version' {$ENDIF} {$ENDIF};
 
+{* This function stores the version of the FreeType2 library in use.
+   TTF_Init() should be called before calling this function.
+ *}
+procedure TTF_GetFreeTypeVersion(major, minor, path: pcint);
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFreeTypeVersion' {$ENDIF} {$ENDIF};
+
+{* This function stores the version of the HarfBuzz library in use,
+   or 0 if HarfBuzz is not available.
+ *}
+procedure TTF_GetHarfBuzzVersion(major, minor, path: pcint);
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetHarfBuzzVersion' {$ENDIF} {$ENDIF};
+
 {* ZERO WIDTH NO-BREAKSPACE (Unicode byte order mark) *}
 const
   UNICODE_BOM_NATIVE  = $FEFF;

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -195,15 +195,19 @@ function TTF_FontFaceFamilyName(font: PTTF_Font): PAnsiChar cdecl; external TTF_
 function TTF_FontFaceStyleName(font: PTTF_Font): PAnsiChar cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_FontFaceStyleName' {$ENDIF} {$ENDIF};
 
 {* Check wether a glyph is provided by the font or not *}
-function TTF_GlyphIsProvided(font: PTTF_Font; ch: cuint16): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphIsProvided' {$ENDIF} {$ENDIF};
+function TTF_GlyphIsProvided(font: PTTF_Font; ch: cuint16): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphIsProvided' {$ENDIF} {$ENDIF};
+function TTF_GlyphIsProvided32(font: PTTF_Font; ch: cuint32): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphIsProvided32' {$ENDIF} {$ENDIF};
 
 {* Get the metrics (dimensions) of a glyph
    To understand what these metrics mean, here is a useful link:
     http://freetype.sourceforge.net/freetype2/docs/tutorial/step2.html
  *}
-function TTF_GlyphMetrics(font: PTTF_Font; ch: cuint16;
-                          minx, maxx: pcint;
-                          miny, maxy: pcint; advance: pcint): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphMetrics' {$ENDIF} {$ENDIF};
+function TTF_GlyphMetrics(font: PTTF_Font; ch: cuint16; minX, maxX, minY, maxY, advance: pcint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphMetrics' {$ENDIF} {$ENDIF};
+function TTF_GlyphMetrics32(font: PTTF_Font; ch: cuint32; minX, maxX, minY, maxY, advance: pcint): cint;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GlyphMetrics32' {$ENDIF} {$ENDIF};
 
 {* Get the dimensions of a rendered string of text *}
 function TTF_SizeText(font: PTTF_Font; text: PAnsiChar; w, h: pcint): cint cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SizeText' {$ENDIF} {$ENDIF};

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -274,6 +274,21 @@ function TTF_RenderText_Shaded(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Co
 function TTF_RenderUTF8_Shaded(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUTF8_Shaded' {$ENDIF} {$ENDIF};
 function TTF_RenderUNICODE_Shaded(font: PTTF_Font; text: pcuint16; fg, bg: TSDL_Color): PSDL_Surface cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUNICODE_Shaded' {$ENDIF} {$ENDIF};
 
+{* Create an 8-bit palettized surface and render the given text at
+   high quality with the given font and colors.  The 0 pixel is background,
+   while other pixels have varying degrees of the foreground color.
+   Text is wrapped to multiple lines on line endings and on word boundaries
+   if it extends beyond wrapLength in pixels.
+   If wrapLength is 0, only wrap on new lines.
+   This function returns the new surface, or NULL if there was an error.
+*}
+function TTF_RenderText_Shaded_Wrapped(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderText_Shaded_Wrapped' {$ENDIF} {$ENDIF};
+function TTF_RenderUTF8_Shaded_Wrapped(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUTF8_Shaded_Wrapped' {$ENDIF} {$ENDIF};
+function TTF_RenderUNICODE_Shaded_Wrapped(font: PTTF_Font; text: pcUint16; fg, bg: TSDL_Color; wrapLength: cUint32): PSDL_Surface;
+  cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderUNICODE_Shaded_Wrapped' {$ENDIF} {$ENDIF};
+
 {* Create an 8-bit palettized surface and render the given glyph at
    high quality with the given font and colors.  The 0 pixel is background,
    while other pixels have varying degrees of the foreground color.


### PR DESCRIPTION
This patch updates `sdl2_ttf.pas` to match `SDL_ttf.h` as of SDL2_ttf v2.0.18.