### PR TITLE
Use the "ctypes" unit on Android

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -116,6 +116,11 @@ interface
       {$ENDIF}
   {$ENDIF}
 
+  {$IF DEFINED(UNIX) AND DEFINED(ANDROID) AND DEFINED(FPC)}
+    uses
+      ctypes;
+  {$ENDIF}
+
 const
 
   {$IFDEF WINDOWS}


### PR DESCRIPTION
Trying to compile `units/sdl2.pas` for Android fails because the `ctypes` unit is not included. This patch fixes the issue.