### PR TITLE
Add cdecl modifier for TSDL_LogOutputFunction

### DIFF
--- a/units/sdllog.inc
+++ b/units/sdllog.inc
@@ -146,13 +146,13 @@ procedure SDL_LogMessageV(category: TSDL_LogCategory; priority: TSDL_LogPriority
  *  \brief The prototype for the log output function
  *}
 type
+  PSDL_LogOutputFunction = ^TSDL_LogOutputFunction;
   TSDL_LogOutputFunction = procedure(
     userdata: Pointer;
     category: TSDL_LogCategory;
     priority: TSDL_LogPriority;
-    const msg: PAnsiChar);
-  PSDL_LogOutputFunction = ^TSDL_LogOutputFunction;
-  
+    const msg: PAnsiChar); cdecl;
+
 {**
  *  \brief Get the current log output function.
  *}


### PR DESCRIPTION
See: [https://www.freepascal.org/docs-html/ref/refsu73.html](https://www.freepascal.org/docs-html/ref/refsu73.html)

"for Pascal functions that are to be used as callbacks for C libraries"

This matches exactly the case when TSDL_LogOutputFunction is used in SDL_LogSetOutputFunction:

procedure SDL_LogSetOutputFunction(callback: TSDL_LogOutputFunction; userdata: Pointer); cdecl;
  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LogSetOutputFunction' {$ENDIF} {$ENDIF};