### PR TITLE
Update GHActions-FPC to v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,32 +17,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2.pas
           verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_gfx.pas
           verbosity: ewnh
       - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_image.pas
           verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_mixer.pas
           verbosity: ewnh
       - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_net.pas
           verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
@@ -53,7 +53,7 @@ jobs:
           sdl2-config --version
           sdl2-config --libs
       - name: Test 1 - Compile Init Test
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testinit.pas
           flags: Fl/usr/local/lib
@@ -62,7 +62,7 @@ jobs:
         run: |
           ./tests/testinit
       - name: Test 2 - Compile Version Test
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testversion.pas
           flags: Fl/usr/local/lib
@@ -81,39 +81,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2.pas
           verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_gfx.pas
           verbosity: ewnh
       - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_image.pas
           verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_mixer.pas
           verbosity: ewnh
       - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_net.pas
           verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
       - name: Install SDL2 library
         run: sudo apt-get install libsdl2-dev
       - name: Test 1 - Compile Init Test
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testinit.pas
           verbosity: ewnh
@@ -123,7 +123,7 @@ jobs:
           export XDG_RUNTIME_DIR=~/tmp
           ./tests/testinit
       - name: Test 2 - Compile Version Test
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testversion.pas
           verbosity: ewnh
@@ -139,37 +139,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Compile SDL2 unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2.pas
           verbosity: ewnh
       - name: Compile SDL2_gfx unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_gfx.pas
           verbosity: ewnh
       - name: Compile SDL2_image unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_image.pas
           verbosity: ewnh
       - name: Compile SDL2_mixer unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_mixer.pas
           verbosity: ewnh
       - name: Compile SDL2_net unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_net.pas
           verbosity: ewnh
       - name: Compile SDL2_ttf unit
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: units/sdl2_ttf.pas
           verbosity: ewnh
       - name: Test 1 - Compile Init Test
-        uses: suve/GHActions-FPC@v0.3.2
+        uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testinit.pas
           flags: Flunits


### PR DESCRIPTION
This commit edits the CI configuration to use the latest release of GHActions-FPC - [v0.4.0](https://github.com/suve/GHActions-FPC/releases/tag/v0.4.0).