### PR TITLE
Remove Pascal function wrappers

### DIFF
--- a/units/sdl2_image.pas
+++ b/units/sdl2_image.pas
@@ -168,7 +168,11 @@ function IMG_SaveJPG_RW(surface: PSDL_Surface; dst: PSDL_RWops; freedst: cint32;
 
 {* We'll use SDL for reporting errors *}
 function IMG_SetError(fmt: PAnsiChar): cint32; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 function IMG_GetError: PAnsiChar; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_GetError' {$ELSE} 'SDL_GetError' {$ENDIF};
 
 implementation
 
@@ -177,16 +181,6 @@ begin
   X.major := SDL_IMAGE_MAJOR_VERSION;
   X.minor := SDL_IMAGE_MINOR_VERSION;
   X.patch := SDL_IMAGE_PATCHLEVEL;
-end;
-
-function IMG_SetError(fmt: PAnsiChar): cint32; cdecl;
-begin
-  Result := SDL_SetError(fmt);
-end;
-
-function IMG_GetError: PAnsiChar; cdecl;
-begin
-  Result := SDL_GetError();
 end;
 
 end.

--- a/units/sdl2_image.pas
+++ b/units/sdl2_image.pas
@@ -167,7 +167,7 @@ function IMG_SaveJPG_RW(surface: PSDL_Surface; dst: PSDL_RWops; freedst: cint32;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SaveJPG_RW' {$ENDIF} {$ENDIF};
 
 {* We'll use SDL for reporting errors *}
-function IMG_SetError(fmt: PAnsiChar): cint32; cdecl;
+function IMG_SetError(fmt: PAnsiChar; args: array of const): cint; cdecl;
   external SDL_LibName
   name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 function IMG_GetError: PAnsiChar; cdecl;

--- a/units/sdl2_mixer.pas
+++ b/units/sdl2_mixer.pas
@@ -666,8 +666,14 @@ procedure Mix_CloseAudio cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MAC
 
 {* We'll use SDL for reporting errors *}
 function Mix_SetError(const fmt: PAnsiChar): cint32; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 function Mix_GetError: PAnsiChar; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_GetError' {$ELSE} 'SDL_GetError' {$ENDIF};
 procedure Mix_ClearError(); cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_ClearError' {$ELSE} 'SDL_ClearError' {$ENDIF};
 
 implementation
 
@@ -696,21 +702,6 @@ end;
 function Mix_LoadWAV(_file: PAnsiChar): PMix_Chunk;
 begin
   Result := Mix_LoadWAV_RW(SDL_RWFromFile(_file, 'rb'), 1);
-end;
-
-function Mix_SetError(const fmt: PAnsiChar): cint32; cdecl;
-begin
-  Result := SDL_SetError(fmt);
-end;
-
-function Mix_GetError: PAnsiChar; cdecl;
-begin
-  Result := SDL_GetError();
-end;
-
-procedure Mix_ClearError; cdecl;
-begin
-  SDL_ClearError()
 end;
 
 end.

--- a/units/sdl2_mixer.pas
+++ b/units/sdl2_mixer.pas
@@ -665,7 +665,7 @@ function Mix_GetChunk(channel: cint): PMix_Chunk cdecl; external MIX_LibName {$I
 procedure Mix_CloseAudio cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_MIX_CloseAudio' {$ENDIF} {$ENDIF};
 
 {* We'll use SDL for reporting errors *}
-function Mix_SetError(const fmt: PAnsiChar): cint32; cdecl;
+function Mix_SetError(const fmt: PAnsiChar; args: array of const): cint; cdecl;
   external SDL_LibName
   name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 function Mix_GetError: PAnsiChar; cdecl;

--- a/units/sdl2_net.pas
+++ b/units/sdl2_net.pas
@@ -345,8 +345,11 @@ procedure SDLNet_FreeSocketSet(set_: TSDLNet_SocketSet) cdecl; external SDLNet_L
 {* Error reporting functions                                           *}
 {***********************************************************************}
 
-procedure SDLNet_SetError(const fmt: PAnsiChar); cdecl;
+procedure SDLNet_SetError(const fmt: PAnsiChar; args: array of const); cdecl;
+external SDLNet_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDLNet_SetError' {$ENDIF} {$ENDIF};
+
 function SDLNet_GetError(): PAnsiChar; cdecl;
+external SDLNet_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDLNet_GetError' {$ENDIF} {$ENDIF};
 
 {***********************************************************************}
 {* Inline functions to read/write network data                         *}
@@ -395,16 +398,6 @@ end;
 function SDLNet_SocketReady(sock: TSDLNet_GenericSocket): cint;
 begin
   Result := sock.ready;
-end;
-
-procedure SDLNet_SetError(const fmt: PAnsiChar); cdecl;
-begin
-  SDL_SetError(fmt);
-end;
-
-function SDLNet_GetError(): PAnsiChar; cdecl;
-begin
-  Result := SDL_GetError();
 end;
 
 (*

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -2258,7 +2258,7 @@ function TTF_GetFontSDF(font: PTTF_Font): TSDL_bool; cdecl;
  *
  * \sa TTF_GetError
   }
-function TTF_SetError(const fmt: PAnsiChar): cint; cdecl;
+function TTF_SetError(const fmt: PAnsiChar; args: array of const): cint; cdecl;
   external SDL_LibName
   name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -2071,9 +2071,15 @@ function TTF_RenderGlyph32_LCD(font: PTTF_Font; ch: cuint32; fg: TSDL_Color; bg:
   external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_RenderGlyph32_LCD' {$ENDIF} {$ENDIF};
 
 {* For compatibility with previous versions, here are the old functions *}
-function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;
-function TTF_RenderUTF8(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;
-function TTF_RenderUNICODE(font: PTTF_Font; text: pcuint16; fg, bg: TSDL_Color): PSDL_Surface;
+function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface; cdecl;
+  external TTF_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_TTF_RenderText_Shaded' {$ELSE} 'TTF_RenderText_Shaded' {$ENDIF};
+function TTF_RenderUTF8(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface; cdecl;
+  external TTF_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_TTF_RenderUTF8_Shaded' {$ELSE} 'TTF_RenderUTF8_Shaded' {$ENDIF};
+function TTF_RenderUNICODE(font: PTTF_Font; text: pcuint16; fg, bg: TSDL_Color): PSDL_Surface; cdecl;
+  external TTF_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_TTF_RenderUNICODE_Shaded' {$ELSE} 'TTF_RenderUNICODE_Shaded' {$ENDIF};
 
 {*
  * Dispose of a previously-created font.
@@ -2253,6 +2259,8 @@ function TTF_GetFontSDF(font: PTTF_Font): TSDL_bool; cdecl;
  * \sa TTF_GetError
   }
 function TTF_SetError(const fmt: PAnsiChar): cint; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_SetError' {$ELSE} 'SDL_SetError' {$ENDIF};
 
 {*
  * Get last SDL_ttf error
@@ -2260,6 +2268,8 @@ function TTF_SetError(const fmt: PAnsiChar): cint; cdecl;
  * \sa TTF_SetError
   }
 function TTF_GetError: PAnsiChar; cdecl;
+  external SDL_LibName
+  name {$IF DEFINED(DELPHI) AND DEFINED(MACOS)} '_SDL_GetError' {$ELSE} 'SDL_GetError' {$ENDIF};
 
 {*
  * Direction flags
@@ -2391,31 +2401,6 @@ begin
   Result := (SDL_TTF_MAJOR_VERSION >= X) and
             ((SDL_TTF_MAJOR_VERSION > X) or (SDL_TTF_MINOR_VERSION >= Y)) and
             ((SDL_TTF_MAJOR_VERSION > X) or (SDL_TTF_MINOR_VERSION > Y) or (SDL_TTF_PATCHLEVEL >= Z));
-end;
-
-function TTF_SetError(const fmt: PAnsiChar): cint; cdecl;
-begin
-  Result := SDL_SetError(fmt);
-end;
-
-function TTF_GetError: PAnsiChar; cdecl;
-begin
-  Result := SDL_GetError();
-end;
-
-function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;
-begin
-  Result := TTF_RenderText_Shaded(font, text, fg, bg);
-end;
-
-function TTF_RenderUTF8(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;
-begin
-  Result := TTF_RenderUTF8_Shaded(font, text, fg, bg);
-end;
-
-function TTF_RenderUNICODE(font: PTTF_Font; text: pcuint16; fg, bg: TSDL_Color): PSDL_Surface;
-begin
-  Result := TTF_RenderUNICODE_Shaded(font, text, fg, bg);
 end;
 
 end.

--- a/units/sdlerror.inc
+++ b/units/sdlerror.inc
@@ -13,7 +13,7 @@
  *
  *  \return -1, there is no error handling for this function
  *}
-function SDL_SetError(const fmt: PAnsiChar): cint; cdecl;
+function SDL_SetError(const fmt: PAnsiChar; args: array of const): cint; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetError' {$ENDIF} {$ENDIF};
 
 {**


### PR DESCRIPTION
In SDL2 addon libraries (SDL2_image, SDL2_mixer, SDL_ttf) there are a couple of functions, which, in the original C headers, are just macros that expand to a different function name. So far, in our Pascal units, these functions were recreated as Pascal functions that called the "real" C functions. This patch removes all of the Pascal wrapper functions and declares each "fake" function as just another name linking to the "real" function.

Note: SDL2_net contains `SDLNet_GetError()` and `SDLNet_SetError()` functions. These, however, actually are separate functions, not macros.