### PR TITLE
Add memory-handling functions to sdlstdinc.inc

### DIFF
--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -13,6 +13,45 @@ const
   SDL_FALSE = TSDL_Bool(0);
   SDL_TRUE  = TSDL_Bool(1);
 
+type
+  TSDL_malloc_func = function(size: csize_t): Pointer; cdecl;
+  PSDL_malloc_func = ^TSDL_malloc_func;
+
+  TSDL_calloc_func = function(nmemb, size: csize_t): Pointer; cdecl;
+  PSDL_calloc_func = ^TSDL_calloc_func;
+
+  TSDL_realloc_func = function(mem: Pointer; size: csize_t): Pointer; cdecl;
+  PSDL_realloc_func = ^TSDL_realloc_func;
+
+  TSDL_free_func = procedure(mem: Pointer); cdecl;
+  PSDL_free_func = ^TSDL_free_func;
+
+(**
+ * Get the current set of SDL memory functions
+ *
+ * \since This function is available since SDL 2.0.7.
+ *)
+procedure SDL_GetMemoryFunctions(
+  malloc_func: PSDL_malloc_func;
+  calloc_func: PSDL_calloc_func;
+  realloc_func: PSDL_realloc_func;
+  free_func: PSDL_free_func
+); cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetMemoryFunctions' {$ENDIF} {$ENDIF};
+
+(**
+ * Replace SDL's memory allocation functions with a custom set
+ *
+ * \since This function is available since SDL 2.0.7.
+ *)
+function SDL_SetMemoryFunctions(
+  malloc_func: TSDL_malloc_func;
+  calloc_func: TSDL_calloc_func;
+  realloc_func: TSDL_realloc_func;
+  free_func: TSDL_free_func
+): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetMemoryFunctions' {$ENDIF} {$ENDIF};
+
 {**
 *  Free memory returned by functions like SDL_GetBasePath(), SDL_GetPrefPath(), etc.
 *}

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -65,8 +65,33 @@ function SDL_SetMemoryFunctions(
 ): cint; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetMemoryFunctions' {$ENDIF} {$ENDIF};
 
-{**
-*  Free memory returned by functions like SDL_GetBasePath(), SDL_GetPrefPath(), etc.
-*}
+(**
+ * Allocate a block of memory. The memory is *not* initialized.
+ *)
+function SDL_malloc(size: csize_t): Pointer; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_malloc' {$ENDIF} {$ENDIF};
+
+(**
+ * Allocate a block of memory that can fit an array of nmemb elements, each of given size.
+ * The memory is initialized by setting every byte to 0.
+ *)
+function SDL_calloc(nmemb, size: csize_t): Pointer; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_calloc' {$ENDIF} {$ENDIF};
+
+(**
+ * Resize a block of memory allocated previously with SDL_malloc() or SDL_calloc().
+ *
+ * The returned pointer may or may not be the same as the original pointer.
+ * If the new size is larger than the old size, any new memory will *not* be initialized.
+ *)
+function SDL_realloc(mem: Pointer; size: csize_t): Pointer; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_realloc' {$ENDIF} {$ENDIF};
+
+(**
+ * Free memory returned by functions like SDL_GetBasePath(), SDL_GetPrefPath(), etc.
+ *
+ * Calling SDL_free() on the same pointer twice is undefined behaviour and may cause
+ * your program to crash or behave in unexpected ways.
+ *)
 procedure SDL_free(mem: Pointer); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_free' {$ENDIF} {$ENDIF};

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -26,6 +26,19 @@ type
   TSDL_free_func = procedure(mem: Pointer); cdecl;
   PSDL_free_func = ^TSDL_free_func;
 
+{**
+ * Get the original set of SDL memory functions
+ *
+ * \since This function is available since SDL 2.24.0.
+ *}
+procedure SDL_GetOriginalMemoryFunctions(
+  malloc_func: PSDL_malloc_func;
+  calloc_func: PSDL_calloc_func;
+  realloc_func: PSDL_realloc_func;
+  free_func: PSDL_free_func
+); cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetOriginalMemoryFunctions' {$ENDIF} {$ENDIF};
+
 (**
  * Get the current set of SDL memory functions
  *

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -66,6 +66,14 @@ function SDL_SetMemoryFunctions(
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetMemoryFunctions' {$ENDIF} {$ENDIF};
 
 (**
+ * Get the number of outstanding (unfreed) allocations
+ *
+ * \since This function is available since SDL 2.0.7.
+ *)
+function SDL_GetNumAllocations(): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetNumAllocations' {$ENDIF} {$ENDIF};
+
+(**
  * Allocate a block of memory. The memory is *not* initialized.
  *)
 function SDL_malloc(size: csize_t): Pointer; cdecl;


### PR DESCRIPTION
This patch adds definitions for:
- `SDL_GetMemoryFunctions()`
- `SDL_SetMemoryFunctions()`
- `SDL_GetNumAllocations()`
- `SDL_GetOriginalMemoryFunctions()`
- `SDL_malloc()`
- `SDL_calloc()`
- `SDL_realloc()`

Fixes #71.