### PR TITLE
Build documentation with PasDoc and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Build documentation using PasDoc and deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install PasDoc
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt update
+          sudo apt install -y pasdoc
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build documentation
+        run: |
+          mkdir gh-pages/
+          pasdoc --output gh-pages/ --format html --ignore-leading '*' --sort constants,functions,types,structures --define FPC --include units/ units/*.pas 
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'gh-pages/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build documentation using PasDoc and deploy to GitHub Pages
+name: Build and deploy documentation
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install PasDoc
         run: |


### PR DESCRIPTION
Since our original discussion in #28, GitHub has added support (currently in beta) for deploying stuff to GitHub Pages from GitHub Actions. This PR adds a workflow that builds documentation using PasDoc and deploys it to GHPages.

One thing to consider: this introduces a new workflow, which is completely independent from the existing build/test workflow. As such, the docs will get build even if the build/test workflow fails. While it's not exactly straight-forward, it is possible to create inter-workflow dependencies in GHActions. The question is, then: do we want the docs workflow to require the build/test workflow to succeed in order to actually launch?