### PR TITLE
Update sdltouch.inc to 2.24.0

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -184,7 +184,7 @@ const
 {$I sdlsensor.inc}
 {$I sdlgamecontroller.inc}       // 2.0.22
 {$I sdlhaptic.inc}
-{$I sdltouch.inc}
+{$I sdltouch.inc}                // 2.24.0
 {$I sdlgesture.inc}
 {$I sdlsyswm.inc}
 {$I sdlevents.inc}

--- a/units/sdltouch.inc
+++ b/units/sdltouch.inc
@@ -24,9 +24,11 @@ type
     pressure: cfloat;
   end;
 
-{* Used as the device ID for mouse events simulated with touch input *}
 const
+  {* Used as the device ID for mouse events simulated with touch input *}
   SDL_TOUCH_MOUSEID = cuint32(-1);
+  {* Used as the SDL_TouchID for touch events simulated with mouse input *}
+  SDL_MOUSE_TOUCHID = TSDL_TouchID(-1);
 
   {* Function prototypes *}
 

--- a/units/sdltouch.inc
+++ b/units/sdltouch.inc
@@ -53,6 +53,14 @@ function SDL_GetTouchDevice(index: cint): TSDL_TouchID; cdecl;
 function SDL_GetTouchName(index: cint): PAnsiChar; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchName' {$ENDIF} {$ENDIF};
 
+{**
+ * Get the type of the given touch device.
+ *
+ * \since This function is available since SDL 2.0.10.
+ *}
+function SDL_GetTouchDeviceType(touchID: TSDL_TouchID): TSDL_TouchDeviceType; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchDeviceType' {$ENDIF} {$ENDIF};
+
   {**
    *  Get the number of active fingers for a given touch device.
    *}

--- a/units/sdltouch.inc
+++ b/units/sdltouch.inc
@@ -7,6 +7,15 @@ type
   PSDL_FingerID = ^TSDL_FingerID;
   TSDL_FingerID = type cint64;
 
+  TSDL_TouchDeviceType = type cint;
+
+const
+  SDL_TOUCH_DEVICE_INVALID           = TSDL_TouchDeviceType(-1);
+  SDL_TOUCH_DEVICE_DIRECT            = TSDL_TouchDeviceType(0);  {* touch screen with window-relative coordinates *}
+  SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE = TSDL_TouchDeviceType(1);  {* trackpad with absolute device coordinates *}
+  SDL_TOUCH_DEVICE_INDIRECT_RELATIVE = TSDL_TouchDeviceType(2);  {* trackpad with relative device coordinates *}
+
+type
   PSDL_Finger = ^TSDL_Finger;
   TSDL_Finger = record
     id: TSDL_FingerID;

--- a/units/sdltouch.inc
+++ b/units/sdltouch.inc
@@ -44,6 +44,15 @@ function SDL_GetNumTouchDevices(): cint; cdecl;
 function SDL_GetTouchDevice(index: cint): TSDL_TouchID; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchDevice' {$ENDIF} {$ENDIF};
 
+{**
+ * Get the touch device name as reported from the driver,
+ * or NIL if the index is invalid.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_GetTouchName(index: cint): PAnsiChar; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchName' {$ENDIF} {$ENDIF};
+
   {**
    *  Get the number of active fingers for a given touch device.
    *}

--- a/units/sdltouch.inc
+++ b/units/sdltouch.inc
@@ -35,20 +35,24 @@ const
   {**
    *  Get the number of registered touch devices.
    *}
-function SDL_GetNumTouchDevices: cint32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetNumTouchDevices' {$ENDIF} {$ENDIF};
+function SDL_GetNumTouchDevices(): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetNumTouchDevices' {$ENDIF} {$ENDIF};
 
   {**
    *  Get the touch ID with the given index, or 0 if the index is invalid.
    *}
-function SDL_GetTouchDevice(index: cint32): TSDL_TouchID cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchDevice' {$ENDIF} {$ENDIF};
+function SDL_GetTouchDevice(index: cint): TSDL_TouchID; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchDevice' {$ENDIF} {$ENDIF};
 
   {**
    *  Get the number of active fingers for a given touch device.
    *}
-function SDL_GetNumTouchFingers(touchID: TSDL_TouchID): cint32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetNumTouchFingers' {$ENDIF} {$ENDIF};
+function SDL_GetNumTouchFingers(touchID: TSDL_TouchID): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetNumTouchFingers' {$ENDIF} {$ENDIF};
 
   {**
    *  Get the finger object of the given touch, with the given index.
    *}
-function SDL_GetTouchFinger(touchID: TSDL_TouchID; index: cint32): PSDL_Finger cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchFinger' {$ENDIF} {$ENDIF};
+function SDL_GetTouchFinger(touchID: TSDL_TouchID; index: cint): PSDL_Finger; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTouchFinger' {$ENDIF} {$ENDIF};
 


### PR DESCRIPTION
This patch updates `sdltouch.inc` to match `SDL_touch.h` as of v2.24.0, by adding new symbols and fixing existing definitions (mainly `cint32` -> `cint` conversion where the C headers say `int`).