### PR TITLE
Update sdlrect.inc to 2.24.0

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -272,6 +272,27 @@ begin
   Result := (r = NIL) or (r^.w <= cfloat(0.0)) or (r^.h <= cfloat(0.0))
 end;
 
+{ FIXME: This the Pascal System.Abs() function, instead of the C SDL_fabsf() function. }
+function SDL_FRectEqualsEpsilon(const a, b: PSDL_FRect; const epsilon: cfloat): Boolean;
+begin
+  Result :=
+    (a <> NIL) and
+    (b <> NIL) and
+    (
+      (a = b)
+      or
+      (
+        (Abs(a^.x - b^.x) <= epsilon)
+        and
+        (Abs(a^.y - b^.y) <= epsilon)
+        and
+        (Abs(a^.w - b^.w) <= epsilon)
+        and
+        (Abs(a^.h - b^.h) <= epsilon)
+      )
+    )
+end;
+
 //from "sdl_atomic.h"
 function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
 begin

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -165,7 +165,7 @@ const
 {$I sdlmutex.inc}                // 2.0.14 WIP
 {$I sdltimer.inc}                // 2.0.18
 {$I sdlpixels.inc}               // 2.0.14 WIP
-{$I sdlrect.inc}                 // 2.0.14
+{$I sdlrect.inc}                 // 2.24.0
 {$I sdlrwops.inc}                // 2.0.14
 {$I sdlaudio.inc}
 {$I sdlblendmode.inc}            // 2.0.14

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -293,6 +293,11 @@ begin
     )
 end;
 
+function SDL_FRectEquals(const a, b: PSDL_FRect): Boolean; Inline;
+begin
+  Result := SDL_FRectEqualsEpsilon(a, b, SDL_FLT_EPSILON)
+end;
+
 //from "sdl_atomic.h"
 function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
 begin

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -259,6 +259,14 @@ begin
   Result := (a^.x = b^.x) and (a^.y = b^.y) and (a^.w = b^.w) and (a^.h = b^.h);
 end;
 
+function SDL_PointInFRect(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean;
+begin
+  Result :=
+    (p^.x >= r^.x) and (p^.x < (r^.x + r^.w))
+    and
+    (p^.y >= r^.y) and (p^.y < (r^.y + r^.h))
+end;
+
 //from "sdl_atomic.h"
 function SDL_AtomicIncRef(atomic: PSDL_Atomic): cint;
 begin

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -251,7 +251,7 @@ end;
 
 function SDL_RectEmpty(const r: PSDL_Rect): Boolean;
 begin
-  Result := (r^.w <= 0) or (r^.h <= 0);
+  Result := (r = NIL) or (r^.w <= 0) or (r^.h <= 0);
 end;
 
 function SDL_RectEquals(const a, b: PSDL_Rect): Boolean;
@@ -265,6 +265,11 @@ begin
     (p^.x >= r^.x) and (p^.x < (r^.x + r^.w))
     and
     (p^.y >= r^.y) and (p^.y < (r^.y + r^.h))
+end;
+
+function SDL_FRectEmpty(const r: PSDL_FRect): Boolean;
+begin
+  Result := (r = NIL) or (r^.w <= cfloat(0.0)) or (r^.h <= cfloat(0.0))
 end;
 
 //from "sdl_atomic.h"

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -125,3 +125,10 @@ function SDL_FRectEmpty(const r: PSDL_FRect): Boolean; inline;
  * \since This function is available since SDL 2.0.22.
  *}
 function SDL_FRectEqualsEpsilon(const a, b: PSDL_FRect; const epsilon: cfloat): Boolean; Inline;
+
+{**
+ * Returns true if the two rectangles are equal, using a default epsilon.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_FRectEquals(const a, b: PSDL_FRect): Boolean; Inline;

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -57,7 +57,7 @@ type
   end;
 
 {**
- *  \brief Returns true if point resides inside a rectangle.
+ *  Returns true if point resides inside a rectangle.
  *}
 function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean; Inline;
 
@@ -111,3 +111,8 @@ function SDL_EnclosePoints(const points: PSDL_Point; count: cint; const clip: PS
  *}
 function SDL_IntersectRectAndLine(const rect: PSDL_Rect; X1, Y1, X2, Y2: pcint): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IntersectRectAndLine' {$ENDIF} {$ENDIF};
+
+{**
+ *  Returns true if point resides inside a rectangle.
+ *}
+function SDL_PointInFRect(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean; Inline;

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -118,3 +118,10 @@ function SDL_PointInFRect(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean; I
  *  Returns true if the rectangle has no area.
  *}
 function SDL_FRectEmpty(const r: PSDL_FRect): Boolean; inline;
+
+{**
+ * Returns true if the two rectangles are equal, within some given epsilon.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_FRectEqualsEpsilon(const a, b: PSDL_FRect; const epsilon: cfloat): Boolean; Inline;

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -166,3 +166,16 @@ function SDL_HasIntersectionF(const a, b: PSDL_FRect): TSDL_Bool; cdecl;
  *}
 function SDL_IntersectFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IntersectFRect' {$ENDIF} {$ENDIF};
+
+{**
+ * Calculate the union of two rectangles with float precision.
+ *
+ * \param A an SDL_FRect structure representing the first rectangle
+ * \param B an SDL_FRect structure representing the second rectangle
+ * \param result an SDL_FRect structure filled in with the union of rectangles
+ *               `A` and `B`
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_UnionFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UnionFRect' {$ENDIF} {$ENDIF};

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -64,9 +64,6 @@ function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean; Inli
 {**
  *  Returns true if the rectangle has no area.
  *}
-
-//changed from variant(b�����h!) to TSDL_Rect
-//maybe PSDL_Rect?
 function SDL_RectEmpty(const r: PSDL_Rect): Boolean; inline;
 
 {**
@@ -116,3 +113,8 @@ function SDL_IntersectRectAndLine(const rect: PSDL_Rect; X1, Y1, X2, Y2: pcint):
  *  Returns true if point resides inside a rectangle.
  *}
 function SDL_PointInFRect(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean; Inline;
+
+{**
+ *  Returns true if the rectangle has no area.
+ *}
+function SDL_FRectEmpty(const r: PSDL_FRect): Boolean; inline;

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -200,3 +200,25 @@ function SDL_UnionFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; 
  *}
 function SDL_EncloseFPoints(const points: PSDL_FPoint; count: cint; const clip: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EncloseFPoints' {$ENDIF} {$ENDIF};
+
+{**
+ * Calculate the intersection of a rectangle and line segment with float
+ * precision.
+ *
+ * This function is used to clip a line segment to a rectangle. A line segment
+ * contained entirely within the rectangle or that does not intersect will
+ * remain unchanged. A line segment that crosses the rectangle at either or
+ * both ends will be clipped to the boundary of the rectangle and the new
+ * coordinates saved in `X1`, `Y1`, `X2`, and/or `Y2` as necessary.
+ *
+ * \param rect an SDL_FRect structure representing the rectangle to intersect
+ * \param X1 a pointer to the starting X-coordinate of the line
+ * \param Y1 a pointer to the starting Y-coordinate of the line
+ * \param X2 a pointer to the ending X-coordinate of the line
+ * \param Y2 a pointer to the ending Y-coordinate of the line
+ * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_IntersectFRectAndLine(const rect: PSDL_FRect; X1, Y1, X2, Y2: pcfloat): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IntersectFRectAndLine' {$ENDIF} {$ENDIF};

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -1,4 +1,4 @@
-//based on "sdl_rect.h" (2.0.14)
+// based on "sdl_rect.h" (2.24.0)
 
 {**
  *  \file SDL_rect.h

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -148,3 +148,21 @@ function SDL_FRectEquals(const a, b: PSDL_FRect): Boolean; Inline;
  *}
 function SDL_HasIntersectionF(const a, b: PSDL_FRect): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasIntersectionF' {$ENDIF} {$ENDIF};
+
+{**
+ * Calculate the intersection of two rectangles with float precision.
+ *
+ * If `result` is NIL then this function will return SDL_FALSE.
+ *
+ * \param A an SDL_FRect structure representing the first rectangle
+ * \param B an SDL_FRect structure representing the second rectangle
+ * \param result an SDL_FRect structure filled in with the intersection of
+ *               rectangles `A` and `B`
+ * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *
+ * \sa SDL_HasIntersectionF
+ *}
+function SDL_IntersectFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IntersectFRect' {$ENDIF} {$ENDIF};

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -132,3 +132,19 @@ function SDL_FRectEqualsEpsilon(const a, b: PSDL_FRect; const epsilon: cfloat): 
  * \since This function is available since SDL 2.0.22.
  *}
 function SDL_FRectEquals(const a, b: PSDL_FRect): Boolean; Inline;
+
+{**
+ * Determine whether two rectangles intersect with float precision.
+ *
+ * If either pointer is NIL the function will return SDL_FALSE.
+ *
+ * \param A an SDL_FRect structure representing the first rectangle
+ * \param B an SDL_FRect structure representing the second rectangle
+ * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *
+ * \sa SDL_IntersectRect
+ *}
+function SDL_HasIntersectionF(const a, b: PSDL_FRect): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasIntersectionF' {$ENDIF} {$ENDIF};

--- a/units/sdlrect.inc
+++ b/units/sdlrect.inc
@@ -179,3 +179,24 @@ function SDL_IntersectFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bo
  *}
 function SDL_UnionFRect(const a, b: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UnionFRect' {$ENDIF} {$ENDIF};
+
+{**
+ * Calculate a minimal rectangle enclosing a set of points with float
+ * precision.
+ *
+ * If `clip` is not NIL then only points inside of the clipping rectangle
+ * are considered.
+ *
+ * \param points an array of SDL_FPoint structures representing points to be
+ *               enclosed
+ * \param count the number of structures in the `points` array
+ * \param clip an SDL_FRect used for clipping or NIL to enclose all points
+ * \param result an SDL_FRect structure filled in with the minimal enclosing
+ *               rectangle
+ * \returns SDL_TRUE if any points were enclosed or SDL_FALSE if all the
+ *          points were outside of the clipping rectangle.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *}
+function SDL_EncloseFPoints(const points: PSDL_FPoint; count: cint; const clip: PSDL_FRect; result: PSDL_FRect): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EncloseFPoints' {$ENDIF} {$ENDIF};

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -13,6 +13,8 @@ const
   SDL_FALSE = TSDL_Bool(0);
   SDL_TRUE  = TSDL_Bool(1);
 
+  SDL_FLT_EPSILON = cfloat(1.1920928955078125e-07);
+
 type
   TSDL_malloc_func = function(size: csize_t): Pointer; cdecl;
   PSDL_malloc_func = ^TSDL_malloc_func;


### PR DESCRIPTION
This patch updates `sdlrect.inc` to match `SDL_rect.h` as of SDL 2.24.0.