### PR TITLE
Add iconv functions

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -432,17 +432,17 @@ end;
 // from "sdl_stdinc.h"
 
 // Note: We're using FPC's Strings.strlen() here, not SDL_strlen().
-function SDL_iconv_utf8_locale(str: PAnsiChar): PAnsiChar; cdecl;
+function SDL_iconv_utf8_locale(Const str: PAnsiChar): PAnsiChar; cdecl;
 begin
   Result := SDL_iconv_string('', 'UTF-8', str, Strings.strlen(str)+1)
 end;
 
-function SDL_iconv_utf8_ucs2(str: PAnsiChar): pcUint16; cdecl;
+function SDL_iconv_utf8_ucs2(Const str: PAnsiChar): pcUint16; cdecl;
 begin
 	Result := pcUint16(SDL_iconv_string('UCS-2-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
 end;
 
-function SDL_iconv_utf8_ucs4(str: PAnsiChar): pcUint32; cdecl;
+function SDL_iconv_utf8_ucs4(Const str: PAnsiChar): pcUint32; cdecl;
 begin
 	Result := pcUint32(SDL_iconv_string('UCS-4-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
 end;

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -203,7 +203,19 @@ const
 
 implementation
 
-uses Strings;
+(*
+ * We need an strlen() implementation for some operations on C-strings.
+ * FPC ships one in the Strings unit; Delphi has one in the AnsiStrings unit.
+ * Since FPC defines "DELPHI" when building in Delphi-compatibility mode,
+ * check if "FPC" is defined to determine which compiler is used.
+ *)
+uses
+	{$IFDEF FPC}
+		Strings
+	{$ELSE}
+		AnsiStrings
+	{$ENDIF}
+	;
 
 // Macros from "sdl_version.h"
 procedure SDL_VERSION(out x: TSDL_Version);
@@ -434,17 +446,17 @@ end;
 // Note: We're using FPC's Strings.strlen() here, not SDL_strlen().
 function SDL_iconv_utf8_locale(Const str: PAnsiChar): PAnsiChar; cdecl;
 begin
-  Result := SDL_iconv_string('', 'UTF-8', str, Strings.strlen(str)+1)
+  Result := SDL_iconv_string('', 'UTF-8', str, strlen(str)+1)
 end;
 
 function SDL_iconv_utf8_ucs2(Const str: PAnsiChar): pcUint16; cdecl;
 begin
-	Result := pcUint16(SDL_iconv_string('UCS-2-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
+	Result := pcUint16(SDL_iconv_string('UCS-2-INTERNAL', 'UTF-8', str, strlen(str)+1))
 end;
 
 function SDL_iconv_utf8_ucs4(Const str: PAnsiChar): pcUint32; cdecl;
 begin
-	Result := pcUint32(SDL_iconv_string('UCS-4-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
+	Result := pcUint32(SDL_iconv_string('UCS-4-INTERNAL', 'UTF-8', str, strlen(str)+1))
 end;
 
 //from "sdl_video.h"

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -203,6 +203,8 @@ const
 
 implementation
 
+uses Strings;
+
 // Macros from "sdl_version.h"
 procedure SDL_VERSION(out x: TSDL_Version);
 begin
@@ -425,6 +427,24 @@ end;
 function SDL_SHAPEMODEALPHA(mode: TWindowShapeMode): Boolean;
 begin
   Result := (mode = ShapeModeDefault) or (mode = ShapeModeBinarizeAlpha) or (mode = ShapeModeReverseBinarizeAlpha);
+end;
+
+// from "sdl_stdinc.h"
+
+// Note: We're using FPC's Strings.strlen() here, not SDL_strlen().
+function SDL_iconv_utf8_locale(str: PAnsiChar): PAnsiChar; cdecl;
+begin
+  Result := SDL_iconv_string('', 'UTF-8', str, Strings.strlen(str)+1)
+end;
+
+function SDL_iconv_utf8_ucs2(str: PAnsiChar): pcUint16; cdecl;
+begin
+	Result := pcUint16(SDL_iconv_string('UCS-2-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
+end;
+
+function SDL_iconv_utf8_ucs4(str: PAnsiChar): pcUint32; cdecl;
+begin
+	Result := pcUint32(SDL_iconv_string('UCS-4-INTERNAL', 'UTF-8', str, Strings.strlen(str)+1))
 end;
 
 //from "sdl_video.h"

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -112,13 +112,13 @@ procedure SDL_free(mem: Pointer); cdecl;
  *
  * \since This function is available since SDL 2.0.0.
  *)
-function SDL_iconv_string(tocode, fromcode, inbuf: PAnsiChar; inbytesleft: csize_t): PAnsiChar; cdecl
+function SDL_iconv_string(Const tocode, fromcode, inbuf: PAnsiChar; inbytesleft: csize_t): PAnsiChar; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_string' {$ENDIF} {$ENDIF};
 
 // These are macros in the original C headers, we will reimplement them as simple Pascal functions.
-function SDL_iconv_utf8_locale(str: PAnsiChar): PAnsiChar; cdecl;
-function SDL_iconv_utf8_ucs2(str: PAnsiChar): pcUint16; cdecl;
-function SDL_iconv_utf8_ucs4(str: PAnsiChar): pcUint32; cdecl;
+function SDL_iconv_utf8_locale(Const str: PAnsiChar): PAnsiChar; cdecl;
+function SDL_iconv_utf8_ucs2(Const str: PAnsiChar): pcUint16; cdecl;
+function SDL_iconv_utf8_ucs4(Const str: PAnsiChar): pcUint32; cdecl;
 
 (* The SDL implementation of iconv() returns these error codes *)
 const
@@ -131,11 +131,11 @@ type
   TSDL_iconv = record end;
   PSDL_iconv = ^TSDL_iconv;
 
-function SDL_iconv_open(tocode, fromcode: PAnsiChar): PSDL_iconv; cdecl;
+function SDL_iconv_open(Const tocode, fromcode: PAnsiChar): PSDL_iconv; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_open' {$ENDIF} {$ENDIF};
 
 function SDL_iconv_close(cd: PSDL_iconv): cint; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_close' {$ENDIF} {$ENDIF};
 
-function SDL_iconv(cd: PSDL_iconv; inbuf: PPAnsiChar; inbytesleft: pcsize_t; outbuf: PPAnsiChar; outbytesleft: pcsize_t): csize_t; cdecl;
+function SDL_iconv(cd: PSDL_iconv; Const inbuf: PPAnsiChar; inbytesleft: pcsize_t; outbuf: PPAnsiChar; outbytesleft: pcsize_t): csize_t; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv' {$ENDIF} {$ENDIF};

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -114,3 +114,8 @@ procedure SDL_free(mem: Pointer); cdecl;
  *)
 function SDL_iconv_string(tocode, fromcode, inbuf: PAnsiChar; inbytesleft: csize_t): PAnsiChar; cdecl
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_string' {$ENDIF} {$ENDIF};
+
+// These are macros in the original C headers, we will reimplement them as simple Pascal functions.
+function SDL_iconv_utf8_locale(str: PAnsiChar): PAnsiChar; cdecl;
+function SDL_iconv_utf8_ucs2(str: PAnsiChar): pcUint16; cdecl;
+function SDL_iconv_utf8_ucs4(str: PAnsiChar): pcUint32; cdecl;

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -119,3 +119,23 @@ function SDL_iconv_string(tocode, fromcode, inbuf: PAnsiChar; inbytesleft: csize
 function SDL_iconv_utf8_locale(str: PAnsiChar): PAnsiChar; cdecl;
 function SDL_iconv_utf8_ucs2(str: PAnsiChar): pcUint16; cdecl;
 function SDL_iconv_utf8_ucs4(str: PAnsiChar): pcUint32; cdecl;
+
+(* The SDL implementation of iconv() returns these error codes *)
+const
+  SDL_ICONV_ERROR  = csize_t(-1);
+  SDL_ICONV_E2BIG  = csize_t(-2);
+  SDL_ICONV_EILSEQ = csize_t(-3);
+  SDL_ICONV_EINVAL = csize_t(-4);
+
+type
+  TSDL_iconv = record end;
+  PSDL_iconv = ^TSDL_iconv;
+
+function SDL_iconv_open(tocode, fromcode: PAnsiChar): PSDL_iconv; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_open' {$ENDIF} {$ENDIF};
+
+function SDL_iconv_close(cd: PSDL_iconv): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_close' {$ENDIF} {$ENDIF};
+
+function SDL_iconv(cd: PSDL_iconv; inbuf: PPAnsiChar; inbytesleft: pcsize_t; outbuf: PPAnsiChar; outbytesleft: pcsize_t): csize_t; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv' {$ENDIF} {$ENDIF};

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -105,3 +105,12 @@ function SDL_realloc(mem: Pointer; size: csize_t): Pointer; cdecl;
  *)
 procedure SDL_free(mem: Pointer); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_free' {$ENDIF} {$ENDIF};
+
+(**
+ * This function converts a string between encodings in one pass, returning a
+ * string that must be freed with SDL_free(), or NIL on error.
+ *
+ * \since This function is available since SDL 2.0.0.
+ *)
+function SDL_iconv_string(tocode, fromcode, inbuf: PAnsiChar; inbytesleft: csize_t): PAnsiChar; cdecl
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_string' {$ENDIF} {$ENDIF};


### PR DESCRIPTION
This changeset adds `SDL_iconv*` functions and related types.

**Note:** Since many other symbols found in `SDL_stdinc.h` are missing from our `sdlstdinc.inc`, some changes have been made:
1. FPC's built-in `Strings.strlen()` is called instead of `SDL_strlen()`, where approriate.
2. The `SDL_iconv_wchar_utf8()` macro is not included in this changeset, as it requires `SDL_wcslen()`.