### PR TITLE
Update sdlgamecontroller.inc to SDL 2.30

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -154,7 +154,7 @@ const
 {$I sdlguid.inc}                 // 2.24.0
 {$I sdljoystick.inc}             // 2.24.0
 {$I sdlsensor.inc}               // 2.26.0
-{$I sdlgamecontroller.inc}       // 2.26.0
+{$I sdlgamecontroller.inc}       // 2.30.0
 {$I sdlhaptic.inc}               // 2.26.2
 {$I sdlhidapi.inc}               // 2.0.18
 {$I sdltouch.inc}                // 2.24.0

--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -154,7 +154,7 @@ const
 {$I sdlguid.inc}                 // 2.24.0
 {$I sdljoystick.inc}             // 2.24.0
 {$I sdlsensor.inc}               // 2.26.0
-{$I sdlgamecontroller.inc}       // 2.24.0
+{$I sdlgamecontroller.inc}       // 2.26.0
 {$I sdlhaptic.inc}               // 2.26.2
 {$I sdlhidapi.inc}               // 2.0.18
 {$I sdltouch.inc}                // 2.24.0

--- a/units/sdlgamecontroller.inc
+++ b/units/sdlgamecontroller.inc
@@ -515,6 +515,32 @@ function SDL_GameControllerGetSensorData(gamecontroller: PSDL_GameController; se
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerGetSensorData' {$ENDIF} {$ENDIF};
 
 {**
+ * Get the current state of a game controller sensor with the timestamp of the
+ * last update.
+ *
+ * The number of values and interpretation of the data is sensor dependent.
+ * See SDL_sensor.h for the details for each type of sensor.
+ *
+ * \param gamecontroller The controller to query
+ * \param type The type of sensor to query
+ * \param timestamp A pointer filled with the timestamp in microseconds of the
+ *                  current sensor reading if available, or 0 if not
+ * \param data A pointer filled with the current sensor state
+ * \param num_values The number of values to write to data
+ * \return 0 or -1 if an error occurred.
+ *
+ * \since This function is available since SDL 2.26.0.
+ *}
+function SDL_GameControllerGetSensorDataWithTimestamp(
+  gamecontroller: PSDL_GameController;
+  senstype: TSDL_SensorType;
+  timestamp: pcuint64;
+  data: pcfloat;
+  num_values: cint
+): cint; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerGetSensorDataWithTimestamp' {$ENDIF} {$ENDIF};
+
+{**
  * Query whether a game controller has rumble support.
  *}
 function SDL_GameControllerHasRumble(gamecontroller: PSDL_GameController): TSDL_Bool; cdecl;

--- a/units/sdlgamecontroller.inc
+++ b/units/sdlgamecontroller.inc
@@ -311,6 +311,20 @@ function SDL_GameControllerGetFirmwareVersion(gamecontroller: PSDL_GameControlle
 function SDL_GameControllerGetSerial(gamecontroller: PSDL_GameController): PAnsiChar; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerGetSerial' {$ENDIF} {$ENDIF};
 
+{**
+ * Get the Steam Input handle of an opened controller, if available.
+ *
+ * Returns an InputHandle_t for the controller that can be used with Steam Input API:
+ * https://partner.steamgames.com/doc/api/ISteamInput
+ *
+ * \param gamecontroller the game controller object to query.
+ * \returns the gamepad handle, or 0 if unavailable.
+ *
+ * \since This function is available since SDL 2.30.0.
+ *}
+function SDL_GameControllerGetSteamHandle(gamecontroller: PSDL_GameController): cuint64; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerGetSteamHandle' {$ENDIF} {$ENDIF};
+
   {**
    *  Returns SDL_TRUE if the controller has been opened and currently connected,
    *  or SDL_FALSE if it has not.


### PR DESCRIPTION
This patch updates `sdlgamecontroller.inc` to match `SDL_gamecontroller.h` as of SDL 2.30.0.