### PR TITLE
Remove empty record types

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -116,9 +116,8 @@ type
 ### Opaque Structs
 
 If you have something like ```typedef struct name name```. the concrete
-structure is opaque. See issue
-[#63](https://github.com/PascalGameDevelopment/SDL2-for-Pascal/issues/63))
-for details.
+structure is opaque, and the programmer is expected to only ever
+interact with pointers to the struct.
 
 C:
 
@@ -128,21 +127,17 @@ typedef struct SDL_Window SDL_Window;
 
 Pascal:
 
-Prefered:
 ```pascal
 type
   PPSDL_Window = ^PSDL_Window;
-  PSDL_Window = ^TSDL_Window;
-  TSDL_Window = type Pointer;
+  PSDL_Window = type Pointer;
 ```
 
-Alternativly:
-```pascal
-type
-  PPSDL_Window = ^PSDL_Window;
-  PSDL_Window = ^TSDL_Window;
-  TSDL_Window = record end;
-```
+As shown above, for opaque structs, we avoid defining the base `TType`
+and define only the pointer `PType`.
+For the rationale behind this decision, read the discussion in
+[issue #63](https://github.com/PascalGameDevelopment/SDL2-for-Pascal/issues/63).
+
 
 ## Unions
 

--- a/units/sdl2_mixer.pas
+++ b/units/sdl2_mixer.pas
@@ -166,8 +166,7 @@ type
 
   {* The internal format for a music chunk interpreted via mikmod *}
   PPMix_Music = ^PMix_Music;
-  PMix_Music = ^TMix_Music;
-  TMix_Music = record end;
+  PMix_Music = type Pointer;
 
   {* Open the mixer with a certain audio format *}
 function Mix_OpenAudio(frequency: cint; format: cuint16; channels: cint; chunksize: cint): cint cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_MIX_OpenAudio' {$ENDIF} {$ENDIF};
@@ -241,7 +240,7 @@ function Mix_HasMusicDecoder(const name: PAnsiChar): TSDL_Bool cdecl;
   {* Find out the music format of a mixer music, or the currently playing
      music, if 'music' is NULL.
   *}
-function Mix_GetMusicType(music: TMix_Music): TMix_MusicType cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_MIX_GetMusicType' {$ENDIF} {$ENDIF};
+function Mix_GetMusicType(music: PMix_Music): TMix_MusicType cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_MIX_GetMusicType' {$ENDIF} {$ENDIF};
 
   {* Set a function that is called after all mixing is performed.
      This can be used to provide real-time visual display of the audio stream

--- a/units/sdl2_ttf.pas
+++ b/units/sdl2_ttf.pas
@@ -175,8 +175,7 @@ procedure TTF_ByteSwappedUNICODE(swapped: TSDL_bool); cdecl;
 {* The internal structure containing font information *}
 type
   PPTTF_Font = ^PTTF_Font;
-  PTTF_Font = ^TTTF_Font;
-  TTTF_Font = record  end; //todo?
+  PTTF_Font = type Pointer;
 
 {*
  * Initialize SDL_ttf.

--- a/units/sdlaudio.inc
+++ b/units/sdlaudio.inc
@@ -942,8 +942,7 @@ function SDL_ConvertAudio(cvt: PSDL_AudioCVT): cint; cdecl;
   }
 { this is opaque to the outside world.  }
 type
-  PSDL_AudioStream = ^TSDL_AudioStream;
-  TSDL_AudioStream = record end;
+  PSDL_AudioStream = type Pointer;
 
 {*
  * Create a new audio stream.

--- a/units/sdlgamecontroller.inc
+++ b/units/sdlgamecontroller.inc
@@ -15,8 +15,7 @@
 {* The gamecontroller structure used to identify an SDL game controller *}
 type
   PPSDL_GameController = ^PSDL_GameController;
-  PSDL_GameController = ^TSDL_GameController;
-  TSDL_GameController = record end;
+  PSDL_GameController = type Pointer;
 
   PPSDL_GameControllerType = ^PSDL_GameControllerType;
   PSDL_GameControllerType = ^TSDL_GameControllerType;

--- a/units/sdlhaptic.inc
+++ b/units/sdlhaptic.inc
@@ -93,8 +93,7 @@
    *}
 type
   PPSDL_Haptic = ^PSDL_Haptic;
-  PSDL_Haptic = ^TSDL_Haptic;
-  TSDL_Haptic = record end;
+  PSDL_Haptic = type Pointer;
 
   {**
    *   Haptic features

--- a/units/sdlhidapi.inc
+++ b/units/sdlhidapi.inc
@@ -42,8 +42,7 @@ type
 	(**
  	 *  \brief  A handle representing an open HID device.
  	 *)
-	PSDL_hid_device = ^TSDL_hid_device;
-	TSDL_hid_device = record end; // opaque struct
+	PSDL_hid_device = type Pointer;
 
 	PSDL_hid_device_info = ^TSDL_hid_device_info;
 

--- a/units/sdljoystick.inc
+++ b/units/sdljoystick.inc
@@ -30,8 +30,7 @@
 type
   {* The joystick structure used to identify an SDL joystick *}
   PPSDL_Joystick = ^PSDL_Joystick;
-  PSDL_Joystick = ^TSDL_Joystick;
-  TSDL_Joystick = record end;
+  PSDL_Joystick = type Pointer;
 
   {* A structure that encodes the stable unique id for a joystick device *}
   PPSDL_JoystickGUID = ^PSDL_JoystickGUID;

--- a/units/sdlrenderer.inc
+++ b/units/sdlrenderer.inc
@@ -91,17 +91,13 @@ type
    *}
 
   PPSDL_Renderer = ^PSDL_Renderer;
-  PSDL_Renderer = ^TSDL_Renderer;
-  TSDL_Renderer = record
-    end;
+  PSDL_Renderer = type Pointer;
 
   {**
    *  An efficient driver-specific representation of pixel data
    *}
   PPSDL_Texture = ^PSDL_Texture;
-  PSDL_Texture = ^TSDL_Texture;
-  TSDL_Texture = record
-    end;
+  PSDL_Texture = type Pointer;
 
   {* Function prototypes *}
 

--- a/units/sdlsensor.inc
+++ b/units/sdlsensor.inc
@@ -10,8 +10,7 @@
  *}
 type
 	PPSDL_Sensor = ^PSDL_Sensor;
-	PSDL_Sensor = ^TSDL_Sensor;
-	TSDL_Sensor = record end;
+	PSDL_Sensor = type Pointer;
 
 {**
  * This is a unique ID for a sensor for the time it is connected to the system,

--- a/units/sdlstdinc.inc
+++ b/units/sdlstdinc.inc
@@ -685,8 +685,7 @@ const
   SDL_ICONV_EINVAL = csize_t(-4);
 
 type
-  TSDL_iconv = record end;
-  PSDL_iconv = ^TSDL_iconv;
+  PSDL_iconv = type Pointer;
 
 function SDL_iconv_open(Const tocode, fromcode: PAnsiChar): PSDL_iconv; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_iconv_open' {$ENDIF} {$ENDIF};

--- a/units/sdlsurface.inc
+++ b/units/sdlsurface.inc
@@ -23,10 +23,7 @@ type
    *  which, if not NULL, contains the raw pixel data for the surface.
    *}
   PPSDL_BlitMap = ^PSDL_BlitMap;
-  PSDL_BlitMap = ^TSDL_BlitMap;
-  TSDL_BlitMap = record
-    map: Pointer;
-  end;
+  PSDL_BlitMap = type Pointer;
 
   PPSDL_Surface = ^PSDL_Surface;
   PSDL_Surface = ^TSDL_Surface;
@@ -51,7 +48,7 @@ type
     clip_rect: TSDL_Rect;        {**< Read-only *}
 
     {** info for fast blit mapping to other surfaces *}
-    map: Pointer;                {**< Private *} // TODO: Check: Why Pointer and not PSDL_BlitMap used here?
+    map: PSDL_BlitMap;           {**< Private *}
 
     {** Reference count -- used when freeing surface *}
     refcount: cint;              {**< Read-mostly *}

--- a/units/sdlthread.inc
+++ b/units/sdlthread.inc
@@ -8,8 +8,7 @@
 
 {* The SDL thread structure, defined in SDL_thread.c *}
 type
-  PSDL_Thread = ^TSDL_Thread;
-  TSDL_Thread = record end;
+  PSDL_Thread = type Pointer;
 
   {* The SDL thread ID *}
   PPSDL_threadID = ^PSDL_threadID;
@@ -340,7 +339,7 @@ procedure SDL_WaitThread(thread: PSDL_Thread; status: pcint); cdecl;
  * \sa SDL_CreateThread
  * \sa SDL_WaitThread
  *}
-procedure SDL_DetachThread(thread:TSDL_Thread); cdecl;
+procedure SDL_DetachThread(thread:PSDL_Thread); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_DetachThread' {$ENDIF}{$ENDIF};
 
   {**

--- a/units/sdlvideo.inc
+++ b/units/sdlvideo.inc
@@ -3,8 +3,7 @@
 
 type
   PPSDL_Window = ^PSDL_Window;
-  PSDL_Window = ^TSDL_Window;
-  TSDL_Window = record end;
+  PSDL_Window = type Pointer;
 
   {**
    *  The structure that defines a display mode


### PR DESCRIPTION
SDL's API contains a lot of opaque data types, where the user is given a pointer and is expected to never dereference it. Until now, we used empty records to denote such types, and then defined pointer types to said empty records. This commit removes all(*) the opaque types and instead declares pointer types using the `type Pointer` notation. This makes it clear that the user is expected not to use the "raw" types, only pointer types, while maintaining type safety.

Check the discussion in issue #63 for more details about the rationale behind this change.

(*) `units/sdl2_net.pas` still contains some empty records. However, that file is very messy right now and needs a proper rewrite.