### PR TITLE
Fixing SDL_AUDIO_ISLITTLEENDIAN in sdl2.pas

### DIFF
--- a/units/sdl2.pas
+++ b/units/sdl2.pas
@@ -351,7 +351,7 @@ end;
 
 function SDL_AUDIO_ISLITTLEENDIAN(x: Cardinal): Cardinal;
 begin
-  Result := not SDL_AUDIO_ISLITTLEENDIAN(x);
+  Result := not SDL_AUDIO_ISBIGENDIAN(x);
 end;
 
 function SDL_AUDIO_ISUNSIGNED(x: Cardinal): Cardinal;


### PR DESCRIPTION
SDL_AUDIO_ISLITTLEENDIAN was calling itself recursively, instead SDL_AUDIO_ISBIGENDIAN