### PR TITLE
Update CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Test 2 - Run Version Test
         run: |
           ./tests/testversion
-  ubuntu-20-04:
-    runs-on: ubuntu-20.04
+  ubuntu-22-04:
+    runs-on: ubuntu-22.04
     steps:
       - name: Install FPC
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  macos-11-big-sur:
-    runs-on: macos-11
+  macos-14-sonoma:
+    runs-on: macos-14
     steps:
       - name: Install FPC
         run: |
@@ -56,7 +56,7 @@ jobs:
         uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testinit.pas
-          flags: Fl/usr/local/lib
+          flags: Fl/opt/homebrew/lib
           verbosity: ewnh
       - name: Test 1 - Run Init Test
         run: |
@@ -65,7 +65,7 @@ jobs:
         uses: suve/GHActions-FPC@v0.4.0
         with:
           source: tests/testversion.pas
-          flags: Fl/usr/local/lib
+          flags: Fl/opt/homebrew/lib
           verbosity: ewnh
       - name: Test 2 - Run Version Test
         run: |


### PR DESCRIPTION
macOS 11 is no longer available as a GitHub Actions runner. This PR switches the macOS CI job from running on macOS 11 Big Sur to running on the latest available release, that being macOS 14 Sonoma. It also updates the Ubuntu job from running on Ubuntu 20.04 to the 22.04 release.